### PR TITLE
Add API resolution limits to FAQ

### DIFF
--- a/pages/app/troubleshooting/faq.mdx
+++ b/pages/app/troubleshooting/faq.mdx
@@ -19,4 +19,7 @@ description: "Frequently asked questions about Hedra."
   <Accordion title="How do I add audio to an image or lipsync?">
     You can add audio to an image and create lipsynced avatar videos using [Hedra Avatar](https://hedra.com/app/video?model=hedra-avatar). Upload your image, provide an audio file, and Hedra Avatar will generate a video with accurate lip-sync. See the [Create Avatar Videos](/app/content-creation/create-ugc-avatar-videos) guide for detailed steps.
   </Accordion>
+  <Accordion title="What is the highest resolution I can use in the API?">
+    1080p for up to 30 seconds on Hedra Avatar and Character-3 (legacy model), up to 8 seconds on Omnia.
+  </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Added a new FAQ entry documenting the maximum resolution limits available in the API. The entry specifies that 1080p is available for up to 30 seconds on Hedra Avatar and Character-3, and up to 8 seconds on Omnia.

**Files changed:**
- `pages/app/troubleshooting/faq.mdx` - Added new accordion item for API resolution limits