### PR TITLE
Fix docs canonical host and broken links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,7 @@
   "logo": {
     "light": "/assets/logo/light.svg",
     "dark": "/assets/logo/dark.svg",
-    "href": "https://hedra.com"
+    "href": "https://www.hedra.com"
   },
   "styling": {
     "eyebrows": "breadcrumbs"
@@ -22,7 +22,7 @@
         {
           "anchor": "Pricing",
           "icon": "credit-card",
-          "href": "https://hedra.com/app/subscription"
+          "href": "https://www.hedra.com/pricing"
         },
         {
           "anchor": "Community",
@@ -32,7 +32,7 @@
         {
           "anchor": "Support",
           "icon": "headset",
-          "href": "https://hedra.com/support"
+          "href": "https://www.hedra.com/support"
         },
         {
           "anchor": "Video Tutorials",
@@ -116,7 +116,7 @@
                 "group": "Editor",
                 "icon": "photo-film-music",
                 "pages": [
-                  "edit-videos-in-composer"
+                  "pages/app/content-creation/edit-videos-in-composer"
                 ]
               },
               {
@@ -235,7 +235,10 @@
     "default": "system"
   },
   "seo": {
-    "indexing": "all"
+    "indexing": "all",
+    "metatags": {
+      "canonical": "https://www.hedra.com/docs"
+    }
   },
   "icons": {
     "library": "tabler"

--- a/pages/app/account/delete-account.mdx
+++ b/pages/app/account/delete-account.mdx
@@ -5,7 +5,7 @@ description: "How to delete your Hedra account and what to know about account re
 
 ## Deleting your account
 
-Navigate to [hedra.com/app/settings/profile](https://hedra.com/app/settings/profile), select **Delete your account**, and confirm.
+Navigate to [www.hedra.com/app/settings/profile](https://www.hedra.com/app/settings/profile), select **Delete your account**, and confirm.
 
 ## Recovering a deleted account
 

--- a/pages/app/billing/annual-subscriptions.mdx
+++ b/pages/app/billing/annual-subscriptions.mdx
@@ -25,5 +25,5 @@ You have complete flexibility in how you use your annual credit allotment:
 
 If you find yourself running low on credits before your annual subscription renews, you have two options:
 
-- **Upgrade** to a higher-tier plan at [hedra.com/app/subscription](https://hedra.com/app/subscription)
+- **Upgrade** to a higher-tier plan at [www.hedra.com/app/subscription](https://www.hedra.com/app/subscription)
 - **Purchase** a one-time credit pack

--- a/pages/app/billing/generation-history.mdx
+++ b/pages/app/billing/generation-history.mdx
@@ -2,7 +2,7 @@
 title: "Generation History & Credit Refunds"
 ---
 
-Your credit usage history is at http://hedra.com/app/settings/billing 
+Your credit usage history is at https://www.hedra.com/app/settings/billing
 
 All generations, refunds, and debits are covered on this page.
 

--- a/pages/app/billing/payment-methods.mdx
+++ b/pages/app/billing/payment-methods.mdx
@@ -5,7 +5,7 @@ description: "Accepted payment methods for Hedra subscriptions."
 
 To pay for your subscription:
 
-1. Visit [hedra.com/plans](https://hedra.com/plans)
+1. Visit [www.hedra.com/pricing](https://www.hedra.com/pricing)
 2. Select your desired subscription plan
 3. Proceed to checkout through our secure Stripe payment system
 

--- a/pages/app/getting-started/overview.mdx
+++ b/pages/app/getting-started/overview.mdx
@@ -15,7 +15,7 @@ Hedra is a creative media platform that uses artificial intelligence to generate
 
 ## Get started
 
-Sign up or log in at [hedra.com](https://hedra.com), then jump into one of the tools below.
+Sign up or log in at [www.hedra.com](https://www.hedra.com), then jump into one of the tools below.
 
 <CardGroup cols={2}>
   <Card icon="image" href="/pages/app/content-creation/create-image" title="Generate an Image">
@@ -27,7 +27,7 @@ Sign up or log in at [hedra.com](https://hedra.com), then jump into one of the t
   <Card icon="microphone" href="/pages/app/content-creation/create-audio" title="Generate Audio">
     Convert text to speech with ElevenLabs, MiniMax, or your cloned voice.
   </Card>
-  <Card icon="waveform-lines" href="/pages/app/content-creation/voice-cloning" title="Clone Your Voice">
+  <Card icon="waveform-lines" href="/pages/app/content-creation/create-audio" title="Clone Your Voice">
     Create a personal voice clone to use across all your content.
   </Card>
 </CardGroup>

--- a/pages/app/troubleshooting/faq.mdx
+++ b/pages/app/troubleshooting/faq.mdx
@@ -17,7 +17,7 @@ description: "Frequently asked questions about Hedra."
     To swap your face, upload the two photos you would like to the Hedra agent on the home screen and type "swap face".
   </Accordion>
   <Accordion title="How do I add audio to an image or lipsync?">
-    You can add audio to an image and create lipsynced avatar videos using [Hedra Avatar](https://hedra.com/app/video?model=hedra-avatar). Upload your image, provide an audio file, and Hedra Avatar will generate a video with accurate lip-sync. See the [Create Avatar Videos](/app/content-creation/create-ugc-avatar-videos) guide for detailed steps.
+    You can add audio to an image and create lipsynced avatar videos using [Hedra Avatar](https://www.hedra.com/app/video?model=hedra-avatar). Upload your image, provide an audio file, and Hedra Avatar will generate a video with accurate lip-sync. See the [Create Avatar Videos](/pages/app/content-creation/create-avatar-video) guide for detailed steps.
   </Accordion>
   <Accordion title="What is the highest resolution I can use in the API?">
     1080p for up to 30 seconds on Hedra Avatar and Character-3 (legacy model), up to 8 seconds on Omnia.

--- a/pages/app/troubleshooting/video-queue.mdx
+++ b/pages/app/troubleshooting/video-queue.mdx
@@ -12,5 +12,5 @@ When using Hedra with a free plan, you may experience longer wait times while yo
 Video processing wait times can take up to several hours depending on the queue length.
 
 <Tip>
-  To achieve faster processing times, consider [upgrading your account](https://hedra.com/plans) to a paid plan.
+  To achieve faster processing times, consider [upgrading your account](https://www.hedra.com/pricing) to a paid plan.
 </Tip>

--- a/pages/developer/getting_started/quickstart.mdx
+++ b/pages/developer/getting_started/quickstart.mdx
@@ -7,11 +7,11 @@ Access almost all of the world's leading image, video, and audio models — incl
 
 ### Step 1: Purchase a paid account
 
-In order to use our API, you'll need a paid subscription account. You can purchase your plans at https://www.hedra.com/plans.
+In order to use our API, you'll need a paid subscription account. You can purchase your plan at https://www.hedra.com/pricing.
 
 ### Step 2: Register an API key
 
-Go to your [profile](https://hedra.com/api-profile), click to generate an API key, and purchase API credits.
+Go to [API keys](https://www.hedra.com/develop/api-keys), generate a key, and purchase API credits.
 
 ### Step 3: Make your first API call
 
@@ -45,4 +45,4 @@ curl https://api.hedra.com/web-app/public/models \
 
 We offer on-demand purchase packs and metered billing on the profile page, with low rate limits and without volume discount.
 
-For configurable rate limits, volume pricing, and more, please submit a ticket via our [enterprise sales form](https://hedra.com/enterprise).
+For configurable rate limits, volume pricing, and more, please submit a ticket via our [enterprise sales form](https://www.hedra.com/enterprise).

--- a/pages/developer/guides/generate-avatar-video.mdx
+++ b/pages/developer/guides/generate-avatar-video.mdx
@@ -113,7 +113,7 @@ curl https://api.hedra.com/web-app/public/voices \
   -H "X-API-Key: $HEDRA_API_KEY"
 ```
 
-See the [Generate Audio](/developer/guides/generate-audio) guide for the full list of voice options, including voice cloning.
+See the [Generate Audio](/pages/developer/guides/generate-audio) guide for the full list of voice options, including voice cloning.
 
 ```bash
 curl -X POST https://api.hedra.com/web-app/public/generations \

--- a/pages/developer/realtime-avatar/get-started.mdx
+++ b/pages/developer/realtime-avatar/get-started.mdx
@@ -23,8 +23,8 @@ LIVEKIT_API_SECRET="<livekit_api_secret>"
 ## Hedra API Access
 
 1. Create a [Hedra](https://www.hedra.com/) account.
-2. [Subscribe to a paid plan](https://www.hedra.com/plans) in order to gain API access.
-3. Navigate to your [API profile page](https://www.hedra.com/api-profile) to generate an API key.
+2. [Subscribe to a paid plan](https://www.hedra.com/pricing) in order to gain API access.
+3. Navigate to [API keys](https://www.hedra.com/develop/api-keys) to generate an API key.
 4. Add your API key to the `.env` file created earlier:
 
 ```env


### PR DESCRIPTION
## What changed

- set the Mintlify canonical base to `https://www.hedra.com/docs`
- normalize docs-owned Hedra links to the canonical `www` host and replace legacy `/plans` and `/api-profile` destinations with current public/developer routes
- correct the Editor navigation path and two stale internal guide links
- point the existing voice-cloning card at the Create Voice guide that documents that workflow

## Why

The post-deploy SE Ranking crawl found that all 52 `canonical3xx` errors came from docs pages emitting `https://hedra.com/docs/...` canonicals, which redirect to `www`. It also found three docs-owned 404 URLs generated by stale navigation or internal links:

- `/docs/app/content-creation/create-ugc-avatar-videos`
- `/docs/developer/guides/generate-audio`
- `/docs/edit-videos-in-composer`

The source references now point directly at existing pages. We intentionally do not retain redirects for those stale paths.

## Impact

Docs pages should emit self-canonical URLs on the production `www` host, avoid unnecessary apex-domain hops, and stop generating the three broken documentation URLs.

## Validation

- `npx --yes mintlify@latest broken-links` — success, no broken links
- `jq empty docs.json`
- `git diff --check`

## Post-deploy verification

Inspect the canonical on a representative docs page and rerun the SE Ranking audit. The separate website sitemap entry for `/docs` still redirects to the docs landing page and should be handled in the website repo after this canonical fix is live.
