### PR TITLE
Fix SEO audit findings: titles, descriptions, heading levels, redirecting links

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -17,6 +17,13 @@
           "Public"
         ],
         "summary": "List Models",
+        "description": "Retrieve the list of AI models available through the Hedra API, including image, video, and audio generation models.",
+        "x-mint": {
+          "metadata": {
+            "title": "List Available AI Models",
+            "description": "Retrieve the list of AI models available through the Hedra API, including image, video, and audio generation models."
+          }
+        },
         "operationId": "list_models_public_models_get",
         "security": [
           {
@@ -78,6 +85,13 @@
           "Public"
         ],
         "summary": "List Voices",
+        "description": "Retrieve the list of text-to-speech voices available for audio generation and avatar videos.",
+        "x-mint": {
+          "metadata": {
+            "title": "List Available Voices",
+            "description": "Retrieve the list of text-to-speech voices available for audio generation and avatar videos."
+          }
+        },
         "operationId": "list_voices_public_voices_get",
         "responses": {
           "200": {
@@ -108,6 +122,13 @@
           "Public"
         ],
         "summary": "List Assets",
+        "description": "Retrieve your uploaded and generated assets, with optional filtering by asset type or IDs.",
+        "x-mint": {
+          "metadata": {
+            "title": "List Uploaded & Generated Assets",
+            "description": "Retrieve your uploaded and generated assets, with optional filtering by asset type or IDs."
+          }
+        },
         "operationId": "list_assets_public_assets_get",
         "security": [
           {
@@ -172,6 +193,7 @@
           "Public"
         ],
         "summary": "Create Asset",
+        "description": "Create a new asset record for an image, audio, or voice file to use in generations.",
         "operationId": "create_asset_public_assets_post",
         "security": [
           {
@@ -218,6 +240,7 @@
           "Public"
         ],
         "summary": "Upload Asset",
+        "description": "Upload the file contents for a previously created asset.",
         "operationId": "upload_asset_public_assets__id__upload_post",
         "security": [
           {
@@ -276,6 +299,13 @@
           "Public"
         ],
         "summary": "List ",
+        "description": "Retrieve a paginated list of your generations, with optional filtering by type, date, or prompt.",
+        "x-mint": {
+          "metadata": {
+            "title": "List Your Generations",
+            "description": "Retrieve a paginated list of your generations, with optional filtering by type, date, or prompt."
+          }
+        },
         "operationId": "list__public_generations_get",
         "security": [
           {
@@ -426,6 +456,7 @@
           "Public"
         ],
         "summary": "Generate Asset",
+        "description": "Start a new image, video, or audio generation using your chosen model and inputs.",
         "operationId": "generate_asset_public_generations_post",
         "security": [
           {
@@ -592,6 +623,13 @@
           "Public"
         ],
         "summary": "Get Status",
+        "description": "Check the status of a generation and retrieve the resulting asset when it completes.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get Generation Status",
+            "description": "Check the status of a generation and retrieve the resulting asset when it completes."
+          }
+        },
         "operationId": "get_status_public_generations__generation_id__status_get",
         "security": [
           {
@@ -640,6 +678,13 @@
           "Public"
         ],
         "summary": "Get Credits",
+        "description": "Retrieve the current API credit balance for your account.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get Your Credit Balance",
+            "description": "Retrieve the current API credit balance for your account."
+          }
+        },
         "operationId": "get_credits_public_billing_credits_get",
         "responses": {
           "200": {

--- a/pages/app/billing/annual-subscriptions.mdx
+++ b/pages/app/billing/annual-subscriptions.mdx
@@ -25,5 +25,5 @@ You have complete flexibility in how you use your annual credit allotment:
 
 If you find yourself running low on credits before your annual subscription renews, you have two options:
 
-- **Upgrade** to a higher-tier plan at [www.hedra.com/app/subscription](https://www.hedra.com/app/subscription)
+- **Upgrade** to a higher-tier plan at [www.hedra.com/pricing](https://www.hedra.com/pricing)
 - **Purchase** a one-time credit pack

--- a/pages/app/billing/generation-history.mdx
+++ b/pages/app/billing/generation-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Generation History & Credit Refunds"
+description: "Where to find your Hedra credit usage history, including all generations, refunds, and debits, in your account billing settings."
 ---
 
 Your credit usage history is at https://www.hedra.com/app/settings/billing

--- a/pages/app/billing/how-credits-work.mdx
+++ b/pages/app/billing/how-credits-work.mdx
@@ -1,5 +1,7 @@
 ---
-title: "FAQ"
+title: "How Credits Work — Hedra Billing & Credits FAQ"
+sidebarTitle: "How Credits Work"
+description: "Answers to common questions about Hedra credits: monthly resets, credit pack rollover, running out of credits, and automatic API top-ups."
 ---
 
 <AccordionGroup>

--- a/pages/app/content-creation/creating-music-videos.mdx
+++ b/pages/app/content-creation/creating-music-videos.mdx
@@ -57,7 +57,7 @@ B-Roll adds depth and pacing but does not typically show the singer performing.
 
 ---
 
-# Method 1: A-Roll Only (Avatar Performance)
+## Method 1: A-Roll Only (Avatar Performance)
 
 Use this method when you want a performance-style music video focused entirely on the artist.
 
@@ -69,7 +69,7 @@ Best for:
 
 ---
 
-## How It Works
+### How It Works
 
 1. Open **Avatar**
 2. Upload an image of the singer
@@ -82,7 +82,7 @@ The avatar’s mouth movement follows the song automatically.
 
 ---
 
-## Lip Sync Notes
+### Lip Sync Notes
 
 - Clear vocal audio produces better sync
 - Avoid heavy distortion or layered effects in the vocal track
@@ -90,7 +90,7 @@ The avatar’s mouth movement follows the song automatically.
 
 ---
 
-## Improving A-Roll
+### Improving A-Roll
 
 You can generate:
 
@@ -102,7 +102,7 @@ Download multiple versions and cut between them in the Editor to create a more d
 
 ---
 
-# Method 2: B-Roll Only (Cinematic Music Video)
+## Method 2: B-Roll Only (Cinematic Music Video)
 
 Use this method when you want a fully visual narrative without showing the singer.
 
@@ -115,7 +115,7 @@ Best for:
 
 ---
 
-## How It Works
+### How It Works
 
 1. Open the **Editor**
 2. Add your song to the **Audio Track**
@@ -134,7 +134,7 @@ This gives you full creative control over timing and structure.
 
 ---
 
-# Method 3: A/B Mix (Performance + Cinematic)
+## Method 3: A/B Mix (Performance + Cinematic)
 
 This is the most common modern music video format.
 
@@ -145,7 +145,7 @@ It blends:
 
 ---
 
-## How It Works
+### How It Works
 
 1. Generate your A-Roll performance
 2. Download or import it into the **Editor**

--- a/pages/app/content-creation/elements-301-production-workflows.mdx
+++ b/pages/app/content-creation/elements-301-production-workflows.mdx
@@ -1,3 +1,4 @@
 ---
 title: "Elements 301: Producers"
+description: "Production workflows for Hedra Elements: how producers plan, organize, and scale consistent character-driven video projects."
 ---

--- a/pages/app/content-creation/elements-401-world-builders.mdx
+++ b/pages/app/content-creation/elements-401-world-builders.mdx
@@ -1,3 +1,4 @@
 ---
 title: "Elements 401: Builders"
+description: "World building with Hedra Elements: advanced techniques for constructing consistent characters, settings, and stories across videos."
 ---

--- a/pages/app/content-creation/upscale-video.mdx
+++ b/pages/app/content-creation/upscale-video.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Upscaling Videos"
+description: "How to upscale your videos to higher resolutions in Hedra: what upscaling does, when to use it, step-by-step instructions, and tips."
 "og:image": "https://www.hedra.com/docs/images/articles/how-to-upscale-videos.png"
 keywords: ["upscaling","topaz","video"]
 ---

--- a/pages/app/getting-started/video-models.mdx
+++ b/pages/app/getting-started/video-models.mdx
@@ -3,7 +3,7 @@ title: "Which Video Model Should I Use?"
 description: "A guide to choosing the right video model in Hedra for your project."
 ---
 
-# Hedra Video Model Guide
+## Hedra Video Model Guide
 
 There isn’t one “best” model. There is a best model for your goal.
 
@@ -16,7 +16,7 @@ If you’re unsure where to begin:
 
 ---
 
-# Hedra Native Models (Recommended Starting Point)
+## Hedra Native Models (Recommended Starting Point)
 
 ---
 
@@ -67,7 +67,7 @@ You need long monologues or large-scale action sequences.
 
 ---
 
-# Premium Cinematic Models
+## Premium Cinematic Models
 
 ---
 
@@ -135,7 +135,7 @@ You are experimenting or testing cheaply.
 
 ---
 
-# Balanced Cinematic Models
+## Balanced Cinematic Models
 
 ---
 
@@ -170,7 +170,7 @@ You need maximum fidelity.
 
 ---
 
-# Budget & Fast Iteration
+## Budget & Fast Iteration
 
 ---
 
@@ -191,7 +191,7 @@ You need dialogue or extended scene control.
 
 ---
 
-# Motion Transfer & Reference Models
+## Motion Transfer & Reference Models
 
 ---
 
@@ -239,7 +239,7 @@ Audio-driven motion between defined frames.
 
 ---
 
-# Avatar Alternatives
+## Avatar Alternatives
 
 ---
 
@@ -276,7 +276,7 @@ Talking videos with expressive lip-sync.
 
 ---
 
-# Credit Strategy Guidance
+## Credit Strategy Guidance
 
 • Start with lower-cost models when testing ideas.\
 • Upgrade to higher-tier models when finalizing.\

--- a/pages/app/troubleshooting/faq.mdx
+++ b/pages/app/troubleshooting/faq.mdx
@@ -1,6 +1,7 @@
 ---
-title: "FAQ"
-description: "Frequently asked questions about Hedra."
+title: "Hedra App FAQ — Troubleshooting & Common Questions"
+sidebarTitle: "FAQ"
+description: "Frequently asked questions about Hedra: video length limits, mobile access, face swap, lip sync, bulk asset management, and API resolutions."
 ---
 
 <AccordionGroup>

--- a/pages/developer/getting_started/quickstart.mdx
+++ b/pages/developer/getting_started/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Quickstart"
+title: "Hedra API Quickstart Guide"
+sidebarTitle: "Quickstart"
 description: "Getting started with the Hedra API is easy."
 ---
 

--- a/pages/developer/realtime-avatar/about.mdx
+++ b/pages/developer/realtime-avatar/about.mdx
@@ -1,5 +1,7 @@
 ---
-title: "About"
+title: "About Hedra Realtime Avatar"
+sidebarTitle: "About"
+description: "Realtime Avatar lets you create your own avatar that can join live, interactive conversations and integrate into your applications."
 ---
 
 Realtime Avatar lets you create your own avatar that can participate in live, interactive conversations. Explore the guides below to get started and seamlessly integrate your avatar into your applications for real-time chat experiences!

--- a/pages/developer/realtime-avatar/expert.mdx
+++ b/pages/developer/realtime-avatar/expert.mdx
@@ -1,9 +1,10 @@
 ---
 title: "Expert Guide"
+description: "Advanced Hedra Realtime Avatar configuration with the LiveKit Agents framework: avatar IDs, image uploads, dependencies, and session management."
 ---
 
 Complete documentation with detailed explanations and advanced configurations using the [Livekit Agents Repository](https://github.com/livekit/agents/tree/main).
-This is helpful to see the various settings under the hood that are leveraged in the [hedra-avatar-starter](https://github.com/hedra-labs/hedra-avatar-starter).
+This is helpful to see the various settings under the hood that are leveraged in the [create-hedra-avatar](https://www.npmjs.com/package/@hedra/create-hedra-avatar) starter.
 
 > **⚠️ Before you begin:**
 > Please make sure you have completed the [Get Started](./get-started) section first to set up all required API keys and environment variables.
@@ -57,7 +58,7 @@ source venv/bin/activate
 
 ### 2. Install other dependencies
 
-As detailed in the [Livekit docs](https://docs.livekit.io/agents/integrations/).
+As detailed in the [Livekit docs](https://docs.livekit.io/agents/models/).
 
 The included example uses OpenAI's realtime model which can be installed with:
 
@@ -146,7 +147,7 @@ End the `agent_worker.py` process using your favorite SIGINT, SIGKILL, etc. mech
 
 ### 4. Use the Livekit CLI
 
-If you've already set up the [Livekit CLI](https://docs.livekit.io/home/cli/cli-setup/) (not covered in this guide) then you can run the following to terminate the room and session:
+If you've already set up the [Livekit CLI](https://docs.livekit.io/intro/basics/cli/) (not covered in this guide) then you can run the following to terminate the room and session:
 
 ```sh
 lk room list

--- a/pages/developer/realtime-avatar/get-started.mdx
+++ b/pages/developer/realtime-avatar/get-started.mdx
@@ -1,5 +1,7 @@
 ---
-title: "Get Started"
+title: "Get Started with Hedra Realtime Avatars"
+sidebarTitle: "Get Started"
+description: "Set up the LiveKit, Hedra, and OpenAI API keys and environment variables required to use Hedra Realtime Avatars."
 ---
 
 This guide will help you set up the required API keys and environment variables for using Hedra Realtime Avatars.

--- a/pages/developer/realtime-avatar/quickstart.mdx
+++ b/pages/developer/realtime-avatar/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quick Setup Guide"
+description: "Scaffold a working Hedra Realtime Avatar application in minutes using the create-hedra-avatar CLI."
 ---
 Get up and running in minutes using create-hedra-avatar.
 > **⚠️ Before you begin:**


### PR DESCRIPTION
Fixes the remaining error-tier findings for the docs subtree in SE Ranking audit 245569 (recheck 2026-07-17). Follow-up to #15. Mintlify auto-deploys on merge, so these land on www.hedra.com/docs immediately.

## title_duplicate + h1_duplicate (2 errors — the last non-infra errors in the audit)
`pages/app/billing/how-credits-work` and `pages/app/troubleshooting/faq` both had title/H1 "FAQ". Each now has a distinct, descriptive title ("How Credits Work — Hedra Billing & Credits FAQ" / "Hedra App FAQ — Troubleshooting & Common Questions"), with `sidebarTitle` keeping the short nav labels. Clears both errors.

## h1_multiple (2 pages)
`creating-music-videos` and `video-models` had `#` headings in the MDX body on top of the front-matter H1. Demoted body H1s to `##` (and their `##` children to `###` where needed to preserve hierarchy). Verified each page now renders exactly one `<h1>`.

## description_missing (18 pages)
- Added front-matter `description` (≤155 chars) to: `billing/generation-history`, `billing/how-credits-work`, `realtime-avatar/{about,get-started,quickstart,expert}`, `content-creation/{elements-301-production-workflows,elements-401-world-builders,upscale-video}`.
- The 9 `api-reference/public/*` pages are generated from `openapi.json`; added operation `description` fields, which Mintlify renders as the meta description (verified via `mint dev`).
- Note: the two Elements pages (301/401) are content-empty stubs — descriptions added per their titles, but they need actual content eventually.

## title_short (11 pages)
- MDX pages: `developer/getting_started/quickstart`, `billing/how-credits-work`, `troubleshooting/faq`, `realtime-avatar/{about,get-started}` — retitled to ≥20 chars including the " - Hedra" suffix, with `sidebarTitle` preserving nav labels.
- API pages (`list-models`, `list-assets`, `list-voices`, `list`, `get-status`, `get-credits`): titles come from the OpenAPI `summary`, which also drives the URL slug — so instead of touching summaries, added `x-mint: metadata` title overrides. **Verified with `mint dev` that all slugs are unchanged** (e.g. `/api-reference/public/list-models` still 200, no new slug created).

## links3xx (5 pages)
All five pages contained exactly one redirecting internal link each, and all are login-gated app routes that 307 to WorkOS auth for any unauthenticated request:
- **Fixed:** `annual-subscriptions` — upgrade CTA now points at the public `https://www.hedra.com/pricing` (matches #15's payment-methods fix).
- **Won't fix (by design):** `forgot-password` (`/login`), `how-to-swap-your-face` (`/app/templates?template=face-swap`), `missing-video` + `delete-content` (`/app/library`). These deep-link users into the app; every unauthenticated hit 307s to the WorkOS AuthKit URL (per-request, can't be hardcoded). The marketing homepage carries identical `/auth/start` and `/app/home` links, so these four flags will persist unless the website serves public shells for those routes — recommend accepting them as crawl noise.

## extlinks4xx (1 dead link)
`realtime-avatar/expert` linked to the removed `github.com/hedra-labs/hedra-avatar-starter` repo — repointed to the live `@hedra/create-hedra-avatar` npm package (the starter the guide scaffolds with). Also fixed two restructured LiveKit docs URLs on the same page that were 308-chaining (`/agents/integrations/` → `/agents/models/`, `/home/cli/cli-setup/` → `/intro/basics/cli/`).

## sitemap_3xx (1) — handoff, not fixed here
`https://www.hedra.com/docs` 308s to `/docs/pages/app/getting-started/overview` and is listed in the **www sitemap** (`www.hedra.com/sitemap.xml`, website repo) — that entry should be updated to the overview URL (or `/docs` made a 200) in the website repo, not here. Separately noticed: Mintlify's own sitemap (`/docs/sitemap.xml`) emits apex-host `https://hedra.com/docs/...` URLs, which all 308 to www — that host comes from the Mintlify dashboard custom-domain setting, not `docs.json`, and is worth fixing there.

## Verification
- `mint dev`: all touched pages render; titles, meta descriptions, and single H1s confirmed; API slugs unchanged.
- `mint broken-links`: no broken links.
- All new titles 20–65 chars (incl. suffix); all descriptions ≤155 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
