### PR TITLE
Add developer About page to docs navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -166,6 +166,7 @@
           {
             "group": "Getting Started",
             "pages": [
+              "pages/developer/getting_started/about",
               "pages/developer/getting_started/quickstart"
             ]
           },

--- a/pages/developer/getting_started/about.mdx
+++ b/pages/developer/getting_started/about.mdx
@@ -1,5 +1,9 @@
 ---
 title: "What is Hedra?"
+sidebarTitle: "About"
+description: "Learn how Hedra provides API access to leading image, video, and audio generation models."
 ---
 
-Hedra is a generative media platform that allows you to create image, text, and audio content via our web platform and APIs.
+Hedra is a generative media platform that allows you to create image, video, and audio content via our web platform and APIs.
+
+When you're ready to make your first API request, follow the [Hedra API Quickstart Guide](/pages/developer/getting_started/quickstart).


### PR DESCRIPTION
## Summary

- Add the developer About page to the API Platform “Getting Started” navigation.
- Add a concise sidebar title and meta description.
- Correct the page’s supported media list and link readers forward to the API quickstart.

## Why

SE Ranking audit 248419 flagged `https://www.hedra.com/docs/pages/developer/getting_started/about` as both an orphan page with no internal inbound links and a page missing a meta description.

The page already existed, but it was omitted from Mintlify’s `docs.json` navigation and did not define a description.

## Impact

Once deployed and recrawled, this should clear one audit error and one warning while making the page discoverable from the docs navigation.

## Validation

- `jq empty docs.json`
- `git diff --check`
