### PR TITLE
Align docs with current product and API

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -51,6 +51,7 @@
               "pages/app/getting-started/overview",
               "pages/app/getting-started/start-with-an-idea",
               "pages/app/getting-started/spaces",
+              "pages/app/getting-started/multiplayer",
               "pages/app/getting-started/library"
             ]
           },
@@ -58,7 +59,6 @@
             "group": "Build with the agent",
             "pages": [
               "pages/app/getting-started/references-and-elements",
-              "pages/app/getting-started/multiplayer",
               "pages/app/getting-started/skills-and-connectors"
             ]
           },

--- a/docs.json
+++ b/docs.json
@@ -58,6 +58,7 @@
             "group": "Build with the agent",
             "pages": [
               "pages/app/getting-started/references-and-elements",
+              "pages/app/getting-started/multiplayer",
               "pages/app/getting-started/skills-and-connectors"
             ]
           },

--- a/openapi.json
+++ b/openapi.json
@@ -476,37 +476,7 @@
                     "$ref": "#/components/schemas/GenerateTextToSpeechRequest"
                   },
                   {
-                    "$ref": "#/components/schemas/GenerateTextToSoundRequest"
-                  },
-                  {
                     "$ref": "#/components/schemas/GenerateImageRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateImageUpscaleRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateVideoUpscaleRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateIsolatedAudioRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateSpeechToSpeechRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateVoiceCloneRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateAudioFromVideoRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateVideoWithAudioRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateVideoToVideoRequest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/GenerateMotionControlRequest-Input"
                   }
                 ],
                 "discriminator": {
@@ -514,18 +484,8 @@
                   "mapping": {
                     "video": "#/components/schemas/GenerateVideoRequest-Input",
                     "text_to_speech": "#/components/schemas/GenerateTextToSpeechRequest",
-                    "text_to_sound": "#/components/schemas/GenerateTextToSoundRequest",
                     "image": "#/components/schemas/GenerateImageRequest",
-                    "image_to_image": "#/components/schemas/GenerateImageRequest",
-                    "image_upscale": "#/components/schemas/GenerateImageUpscaleRequest",
-                    "video_upscale": "#/components/schemas/GenerateVideoUpscaleRequest",
-                    "audio_isolation": "#/components/schemas/GenerateIsolatedAudioRequest",
-                    "speech_to_speech": "#/components/schemas/GenerateSpeechToSpeechRequest",
-                    "voice_clone": "#/components/schemas/GenerateVoiceCloneRequest",
-                    "audio_from_video": "#/components/schemas/GenerateAudioFromVideoRequest",
-                    "video_with_audio": "#/components/schemas/GenerateVideoWithAudioRequest",
-                    "video_to_video": "#/components/schemas/GenerateVideoToVideoRequest",
-                    "motion_control": "#/components/schemas/GenerateMotionControlRequest-Input"
+                    "image_to_image": "#/components/schemas/GenerateImageRequest"
                   }
                 },
                 "title": "Generate Request"
@@ -547,37 +507,7 @@
                       "$ref": "#/components/schemas/GenerateTextToSpeechResponse"
                     },
                     {
-                      "$ref": "#/components/schemas/GenerateTextToSoundResponse"
-                    },
-                    {
                       "$ref": "#/components/schemas/GenerateImageResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateImageUpscaleResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateVideoUpscaleResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateIsolatedAudioResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateSpeechToSpeechResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateVoiceCloneResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateAudioFromVideoResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateVideoWithAudioResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateVideoToVideoResponse"
-                    },
-                    {
-                      "$ref": "#/components/schemas/GenerateMotionControlResponse"
                     }
                   ],
                   "discriminator": {
@@ -585,18 +515,8 @@
                     "mapping": {
                       "video": "#/components/schemas/GenerateVideoResponse",
                       "text_to_speech": "#/components/schemas/GenerateTextToSpeechResponse",
-                      "text_to_sound": "#/components/schemas/GenerateTextToSoundResponse",
                       "image": "#/components/schemas/GenerateImageResponse",
-                      "image_to_image": "#/components/schemas/GenerateImageResponse",
-                      "image_upscale": "#/components/schemas/GenerateImageUpscaleResponse",
-                      "video_upscale": "#/components/schemas/GenerateVideoUpscaleResponse",
-                      "audio_isolation": "#/components/schemas/GenerateIsolatedAudioResponse",
-                      "speech_to_speech": "#/components/schemas/GenerateSpeechToSpeechResponse",
-                      "voice_clone": "#/components/schemas/GenerateVoiceCloneResponse",
-                      "audio_from_video": "#/components/schemas/GenerateAudioFromVideoResponse",
-                      "video_with_audio": "#/components/schemas/GenerateVideoWithAudioResponse",
-                      "video_to_video": "#/components/schemas/GenerateVideoToVideoResponse",
-                      "motion_control": "#/components/schemas/GenerateMotionControlResponse"
+                      "image_to_image": "#/components/schemas/GenerateImageResponse"
                     }
                   },
                   "title": "Response Generate Asset Public Generations Post"
@@ -1698,10 +1618,18 @@
             "description": "The id of the Image asset to use as the start keyframe. This will be ignored if reference_image_ids is provided."
           },
           "ai_model_id": {
-            "type": "string",
-            "format": "uuid",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Ai Model Id",
-            "description": "The model to use."
+            "description": "Deprecated. Use model_slug to select the model.",
+            "deprecated": true
           },
           "reference_image_ids": {
             "anyOf": [
@@ -1732,12 +1660,23 @@
             "title": "Enhance Prompt",
             "description": "If true, automatically enhance the prompt before generation.",
             "default": false
+          },
+          "model_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Slug",
+            "description": "The slug of the model to use. Alternative to ai_model_id."
           }
         },
         "type": "object",
         "required": [
-          "text_prompt",
-          "ai_model_id"
+          "text_prompt"
         ],
         "title": "GenerateImageRequest"
       },
@@ -1848,10 +1787,18 @@
             "description": "The id of the Image asset to use as the start keyframe. This will be ignored if reference_image_ids is provided."
           },
           "ai_model_id": {
-            "type": "string",
-            "format": "uuid",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Ai Model Id",
-            "description": "The model to use."
+            "description": "Deprecated. Use model_slug to select the model.",
+            "deprecated": true
           },
           "reference_image_ids": {
             "anyOf": [
@@ -1940,12 +1887,23 @@
             "type": "array",
             "title": "Batch Results",
             "description": "All generation results in the batch. Always populated (even for batch_size=1). The main response fields (id, asset_id, etc.) reflect the first successful generation."
+          },
+          "model_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Slug",
+            "description": "The slug of the model to use. Alternative to ai_model_id."
           }
         },
         "type": "object",
         "required": [
           "text_prompt",
-          "ai_model_id",
           "asset_id",
           "id",
           "created_at",
@@ -3319,7 +3277,8 @@
               }
             ],
             "title": "Model Id",
-            "description": "The id of the model to use."
+            "description": "Deprecated. Use model_slug to select the model.",
+            "deprecated": true
           },
           "text": {
             "type": "string",
@@ -3346,6 +3305,18 @@
             "$ref": "#/components/schemas/SupportedLanguage",
             "description": "Language for TTS. See SupportedLanguage enum for valid values. Defaults to 'auto'.",
             "default": "auto"
+          },
+          "model_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Slug",
+            "description": "The slug of the model to use. Alternative to model_id."
           }
         },
         "type": "object",
@@ -3433,7 +3404,8 @@
               }
             ],
             "title": "Model Id",
-            "description": "The id of the model to use."
+            "description": "Deprecated. Use model_slug to select the model.",
+            "deprecated": true
           },
           "text": {
             "type": "string",
@@ -3498,6 +3470,18 @@
             ],
             "title": "Eta Sec",
             "description": "Estimated time until completion in seconds. May be None if no historical data available."
+          },
+          "model_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Slug",
+            "description": "The slug of the model to use. Alternative to model_id."
           }
         },
         "type": "object",
@@ -3574,11 +3558,18 @@
             "default": "video"
           },
           "ai_model_id": {
-            "type": "string",
-            "format": "uuid",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Ai Model Id",
-            "description": "ID of the model to use for the generation.",
-            "default": "d1dd37a3-e39a-4854-a298-6510289f9cf2"
+            "description": "Deprecated. Use model_slug to select the model.",
+            "deprecated": true
           },
           "start_keyframe_id": {
             "anyOf": [
@@ -3712,6 +3703,18 @@
             "title": "Batch Size",
             "description": "Number of video variations to generate (1-8). When > 1, batch_results will contain all generation results.",
             "default": 1
+          },
+          "model_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Slug",
+            "description": "Slug of the model to use for the generation. Alternative to ai_model_id."
           }
         },
         "type": "object",
@@ -3782,11 +3785,18 @@
             "default": "video"
           },
           "ai_model_id": {
-            "type": "string",
-            "format": "uuid",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Ai Model Id",
-            "description": "ID of the model to use for the generation.",
-            "default": "d1dd37a3-e39a-4854-a298-6510289f9cf2"
+            "description": "Deprecated. Use model_slug to select the model.",
+            "deprecated": true
           },
           "start_keyframe_id": {
             "anyOf": [
@@ -3920,6 +3930,18 @@
             "title": "Batch Size",
             "description": "Number of video variations to generate (1-8). When > 1, batch_results will contain all generation results.",
             "default": 1
+          },
+          "model_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Slug",
+            "description": "Slug of the model to use for the generation. Alternative to ai_model_id."
           }
         },
         "type": "object",
@@ -3990,11 +4012,18 @@
             "default": "video"
           },
           "ai_model_id": {
-            "type": "string",
-            "format": "uuid",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Ai Model Id",
-            "description": "ID of the model to use for the generation.",
-            "default": "d1dd37a3-e39a-4854-a298-6510289f9cf2"
+            "description": "Deprecated. Use model_slug to select the model.",
+            "deprecated": true
           },
           "start_keyframe_id": {
             "anyOf": [
@@ -4186,6 +4215,18 @@
             "type": "array",
             "title": "Batch Results",
             "description": "All generation results in the batch. Always populated (even for batch_size=1). The main response fields (id, asset_id, etc.) reflect the first successful generation."
+          },
+          "model_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Slug",
+            "description": "Slug of the model to use for the generation. Alternative to ai_model_id."
           }
         },
         "type": "object",

--- a/pages/app/content-creation/create-audio.mdx
+++ b/pages/app/content-creation/create-audio.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Audio"
+title: "Speech"
 description: "Generate spoken audio with voice selection, synthesis controls, and expressive tags."
 ---
 

--- a/pages/app/content-creation/edit-videos-in-composer.mdx
+++ b/pages/app/content-creation/edit-videos-in-composer.mdx
@@ -1,10 +1,11 @@
 ---
-title: "Composer"
+title: "Edit Video"
 description: "Assemble generated and uploaded media into a timed video composition."
 ---
 
-Composer is Hedra's timeline editor. Use it after inference when the final result
-needs multiple clips, timing control, audio, or a single exported file.
+Edit Video is Hedra's timeline editor, also referred to as Composer. Use it after
+inference when the final result needs multiple clips, timing control, audio, or a
+single exported file.
 
 ## Start or reopen a composition
 

--- a/pages/app/getting-started/library.mdx
+++ b/pages/app/getting-started/library.mdx
@@ -5,7 +5,7 @@ description: "Find, group, reuse, share, and manage the media and Elements creat
 
 The Library is the durable home for work created or uploaded in Hedra. Use it to
 find media across Spaces, organize assets into Projects, manage Elements, and
-return to work you have favorited or received from someone else.
+return to work you have favorited or Projects someone shared with you.
 
 <Frame caption="The Library brings media, Projects, Elements, favorites, and shared work together.">
   ![The Hedra Library with My work, Projects, Elements, Favorites, and Shared with me tabs](/images/product/library.webp)
@@ -19,10 +19,10 @@ return to work you have favorited or received from someone else.
 | **Projects** | Collections you create to keep related assets together. |
 | **Elements** | Reusable characters, environments, styles, outfits, and brand identities. |
 | **Favorites** | Assets you marked for quick access. |
-| **Shared with me** | Work another Hedra user shared with you. |
+| **Shared with me** | Projects another Hedra user shared with you. |
 
 Use **Search** to find an asset, the media-type filter to narrow results, and
-**Date created** to change the sort order.
+**Date created** to filter work created before, after, or within a date range.
 
 ## Projects
 

--- a/pages/app/getting-started/manual-tools.mdx
+++ b/pages/app/getting-started/manual-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Use manual tools"
-description: "Choose Image, Video, Audio, or Composer when you want direct control over a generation or edit."
+description: "Choose Image, Video, Speech, or Edit Video when you want direct control over a generation or edit."
 ---
 
 Manual tools are direct creative interfaces. Use one when you already know what
@@ -14,8 +14,8 @@ perform one defined operation at a time.
 | --- | --- |
 | **[Image](/pages/app/getting-started/manual-image)** | You want to generate or edit an image with a specific model, references, aspect ratio, resolution, or batch size. |
 | **[Video](/pages/app/getting-started/video-models)** | You want to generate, animate, transition, create an avatar performance, or upscale video with explicit model controls. |
-| **[Audio](/pages/app/content-creation/create-audio)** | You want to select a voice and generate speech from a script. |
-| **[Composer](/pages/app/content-creation/edit-videos-in-composer)** | You want to arrange clips and audio on a timeline and export a finished video. |
+| **[Speech](/pages/app/content-creation/create-audio)** | You want to select a voice and generate spoken audio from a script. |
+| **[Edit Video](/pages/app/content-creation/edit-videos-in-composer)** | You want to arrange clips and audio on a timeline and export a finished video. |
 
 ## How manual tools work
 

--- a/pages/app/getting-started/multiplayer.mdx
+++ b/pages/app/getting-started/multiplayer.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Collaborate in realtime"
+title: "Realtime multiplayer"
 description: "Invite teammates to a Space by email, choose their access, and work together on the same live canvas."
 ---
 

--- a/pages/app/getting-started/multiplayer.mdx
+++ b/pages/app/getting-started/multiplayer.mdx
@@ -1,0 +1,56 @@
+---
+title: "Collaborate in realtime"
+description: "Invite teammates to a Space by email, choose their access, and work together on the same live canvas."
+---
+
+Share a Space when teammates need to review or shape the visual work with you.
+Collaborators join the same realtime canvas, so edits and generation progress stay
+in sync without exporting or duplicating the work.
+
+## Invite a teammate by email
+
+<Steps>
+  <Step title="Open sharing">
+    Open the Space and select **Share**.
+  </Step>
+  <Step title="Add their email">
+    Under **Add people by email**, enter your teammate's email address.
+  </Step>
+  <Step title="Choose their role">
+    Select **Can view** for review-only access or **Can edit** when they should be
+    able to arrange and modify canvas content.
+  </Step>
+  <Step title="Grant access">
+    Select **Add**. Hedra grants access immediately for an existing account. If the
+    address does not have an account yet, Hedra sends an invitation and marks the
+    person as pending until they sign up with that address.
+  </Step>
+</Steps>
+
+## What collaborators can access
+
+- **Can view** gives live, read-only access to the canvas.
+- **Can edit** lets a teammate arrange and edit canvas content with you.
+- The shared canvas includes its assets and the prompts used to create them.
+- Your Agent chat history stays private. Sharing a Space does not share your
+  conversation with collaborators.
+
+Canvas changes synchronize as people work. Generation status updates are also
+relayed to connected viewers and editors, so everyone sees current progress.
+
+## Manage access
+
+Open **Share** to see **People with access**. You can change a person's role or
+remove their access at any time.
+
+Under **General Access**, choose:
+
+- **Private** to limit the Space to you;
+- **Only people invited** to allow named collaborators;
+- **Anyone with the link → Can View** for link-based review;
+- **Anyone with the link → Can Edit** for open link-based collaboration.
+
+<Warning>
+  Anyone-edit links let every person with the link modify the canvas. Prefer email
+  invitations when you need named access and a separate role for each teammate.
+</Warning>

--- a/pages/app/getting-started/skills-and-connectors.mdx
+++ b/pages/app/getting-started/skills-and-connectors.mdx
@@ -30,7 +30,7 @@ Create a custom Skill when you repeatedly specify the same:
     Select **Personalize** in the sidebar, then open **Skills**.
   </Step>
   <Step title="Create a Skill">
-    Select **New skill** and describe the instructions the agent should follow.
+    Select **New** and describe the instructions the agent should follow.
   </Step>
   <Step title="Use it from a prompt">
     Select the Skill from the home screen or invoke it while working in a Space,

--- a/pages/app/getting-started/spaces.mdx
+++ b/pages/app/getting-started/spaces.mdx
@@ -44,7 +44,7 @@ stay connected.
   <div>
     <h3>Choose the interface that matches the work</h3>
     <p>Use a <strong>Space</strong> when the task benefits from planning, research, multiple steps, references, or conversational iteration. The Agent can move between capabilities while the conversation and canvas preserve the project context.</p>
-    <p>Use a <strong>manual tool</strong> when you already know the single operation, model, inputs, and settings you want. Image, Video, Audio, and Composer provide direct controls without changing the Space workflow.</p>
+    <p>Use a <strong>manual tool</strong> when you already know the single operation, model, inputs, and settings you want. Image, Video, Speech, and Edit Video provide direct controls without changing the Space workflow.</p>
     <p>Outputs from either path remain available in the Library and can be brought back into a Space as references.</p>
     <p><a href="/pages/app/getting-started/manual-tools">Compare the manual tools →</a></p>
   </div>
@@ -53,30 +53,18 @@ stay connected.
     <p className="text-sm text-gray-500">Manual Image</p>
     <img src="/images/product/manual-video.webp" alt="Manual Video tool with operation, model, reference, and output controls" className="rounded-xl border border-gray-200 dark:border-white/10" />
     <p className="text-sm text-gray-500">Manual Video</p>
-    <img src="/images/product/manual-speech.webp" alt="Manual Audio tool with voice, synthesis, and script controls" className="rounded-xl border border-gray-200 dark:border-white/10" />
-    <p className="text-sm text-gray-500">Manual Audio</p>
+    <img src="/images/product/manual-speech.webp" alt="Manual Speech tool with voice, synthesis, and script controls" className="rounded-xl border border-gray-200 dark:border-white/10" />
+    <p className="text-sm text-gray-500">Manual Speech</p>
   </div>
 </div>
 
-## Realtime multiplayer
+## Work with teammates
 
-A Space can be shared without exporting or duplicating the canvas. Select
-**Share** to invite people by email or change general access for the link.
+Share the canvas with named teammates or by link when the work needs review or
+collaborative editing. Canvas activity stays synchronized in realtime, while your
+Agent chat history remains private.
 
-- **Can view** gives someone live, read-only access to the canvas.
-- **Can edit** lets them arrange and edit canvas content with you.
-- **Private** limits access to the owner and specifically invited people.
-- **Anyone with the link** can be configured for viewing or editing.
-
-Connected collaborators join the same realtime canvas room. Canvas changes
-synchronize as people work, and generation status updates are relayed to connected
-viewers and editors so the shared Space does not fall out of sync.
-
-<Note>
-  Share access deliberately. Anyone-edit links allow every person with the link to
-  modify the Space. Use individual invitations when you need named access and
-  per-person roles.
-</Note>
+[Learn how to invite teammates and manage Space access →](/pages/app/getting-started/multiplayer)
 
 <Tip>
   Keep one creative objective per Space. The agent can use earlier decisions more

--- a/pages/app/getting-started/spaces.mdx
+++ b/pages/app/getting-started/spaces.mdx
@@ -38,26 +38,6 @@ stay connected.
   </Step>
 </Steps>
 
-## Spaces and manual tools
-
-<div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
-  <div>
-    <h3>Choose the interface that matches the work</h3>
-    <p>Use a <strong>Space</strong> when the task benefits from planning, research, multiple steps, references, or conversational iteration. The Agent can move between capabilities while the conversation and canvas preserve the project context.</p>
-    <p>Use a <strong>manual tool</strong> when you already know the single operation, model, inputs, and settings you want. Image, Video, Speech, and Edit Video provide direct controls without changing the Space workflow.</p>
-    <p>Outputs from either path remain available in the Library and can be brought back into a Space as references.</p>
-    <p><a href="/pages/app/getting-started/manual-tools">Compare the manual tools →</a></p>
-  </div>
-  <div className="space-y-4">
-    <img src="/images/product/manual-image.webp" alt="Manual Image tool with model, references, prompt, and output settings" className="rounded-xl border border-gray-200 dark:border-white/10" />
-    <p className="text-sm text-gray-500">Manual Image</p>
-    <img src="/images/product/manual-video.webp" alt="Manual Video tool with operation, model, reference, and output controls" className="rounded-xl border border-gray-200 dark:border-white/10" />
-    <p className="text-sm text-gray-500">Manual Video</p>
-    <img src="/images/product/manual-speech.webp" alt="Manual Speech tool with voice, synthesis, and script controls" className="rounded-xl border border-gray-200 dark:border-white/10" />
-    <p className="text-sm text-gray-500">Manual Speech</p>
-  </div>
-</div>
-
 ## Work with teammates
 
 Share the canvas with named teammates or by link when the work needs review or

--- a/pages/app/getting-started/start-with-an-idea.mdx
+++ b/pages/app/getting-started/start-with-an-idea.mdx
@@ -32,16 +32,17 @@ The controls below the prompt help the agent work with more than text:
 
 | Control | Use it for |
 | --- | --- |
-| **References** | Upload or select media the agent should inspect, preserve, transform, or build from. |
+| **Add reference asset** | Upload or select media the agent should inspect, preserve, transform, or build from. |
 | **Commands** | Invoke a specific capability when you want to direct how the task is performed. |
 | **Elements** | Bring in reusable characters, products, styles, outfits, or environments. |
 | **Connectors** | Give the agent access to context from a connected service. |
 
 ## Use a starter Skill
 
-The cards below the prompt are ready-made Skills for common outcomes such as a
-storyboard, UGC ad, product spot, presenter video, animation, or short. Selecting
-one gives the agent a proven starting workflow that you can still customize.
+The Video, Image, and Research cards below the prompt are ready-made Skills for
+common outcomes such as a storyboard, UGC ad, product spot, presenter video,
+animation, campaign brief, or competitor scan. Selecting one gives the agent a
+proven starting workflow that you can still customize.
 
 <Note>
   A Skill can provide a starting workflow; your message remains the source of truth
@@ -58,5 +59,10 @@ Keep the second composition, but make the lighting warmer and turn it
 into a four-shot storyboard.
 ```
 
-The conversation and canvas share context, so the agent can build on the work you
-are reviewing.
+The Agent receives the current canvas state when you send a message, so it can
+build on the work you are reviewing.
+
+<Note>
+  Sharing a Space shares the canvas, its assets, and the prompts used to create
+  them. Your Agent chat history stays private.
+</Note>

--- a/pages/app/getting-started/start-with-an-idea.mdx
+++ b/pages/app/getting-started/start-with-an-idea.mdx
@@ -6,10 +6,6 @@ description: "Brief the Hedra agent and give it the context it needs to complete
 The home prompt is the fastest way to begin. Describe the result you want rather
 than translating your idea into a sequence of tools.
 
-<Frame caption="Start with a goal, then add references and capabilities as needed.">
-  ![Hedra agent prompt with a conversational brief and starter skills](/images/product/agent-home.webp)
-</Frame>
-
 ## Write an outcome-oriented brief
 
 A useful first message answers five questions:

--- a/pages/developer/getting_started/quickstart.mdx
+++ b/pages/developer/getting_started/quickstart.mdx
@@ -6,13 +6,15 @@ description: "Getting started with the Hedra API is easy."
 
 Access almost all of the world's leading image, video, and audio models — including Nano Banana Pro, Veo, Grok, Kling, and more — via the Hedra API, using the same account your team uses to create content on the Hedra platform.
 
-### Step 1: Purchase a paid account
+### Step 1: Use a paid Hedra account
 
-In order to use our API, you'll need a paid subscription account. You can purchase your plan at https://www.hedra.com/pricing.
+The public API requires a paid Hedra subscription and uses the same Studio
+credit balance as the Hedra app.
 
 ### Step 2: Register an API key
 
-Go to [API keys](https://www.hedra.com/develop/api-keys), generate a key, and purchase API credits.
+Go to [API keys](https://www.hedra.com/develop/api-keys) and generate a key. Make
+sure the account has enough Studio credits for the generation you want to run.
 
 ### Step 3: Make your first API call
 
@@ -29,7 +31,7 @@ curl https://api.hedra.com/web-app/public/models \
 
 <CardGroup cols={2}>
   <Card title="Generate an Image" href="/pages/developer/guides/generate-image">
-    Generate images from text prompts using models like Sana and Flux.
+    Generate images from text prompts using models like Nano Banana Pro.
   </Card>
   <Card title="Generate a Video" href="/pages/developer/guides/generate-video">
     Create videos from images and text prompts using partner video models.
@@ -42,8 +44,7 @@ curl https://api.hedra.com/web-app/public/models \
   </Card>
 </CardGroup>
 
-### [Optional] Enterprise
+### Enterprise
 
-We offer on-demand purchase packs and metered billing on the profile page, with low rate limits and without volume discount.
-
-For configurable rate limits, volume pricing, and more, please submit a ticket via our [enterprise sales form](https://www.hedra.com/enterprise).
+For configurable rate limits, volume pricing, and more, contact Hedra through our
+[enterprise sales form](https://www.hedra.com/enterprise).

--- a/pages/developer/guides/automate-with-n8n.mdx
+++ b/pages/developer/guides/automate-with-n8n.mdx
@@ -37,9 +37,9 @@ This workflow generates a daily image from a prompt.
 {
   "type": "image",
   "text_prompt": "A vibrant abstract background for social media",
-  "ai_model_id": "a66300b4-f76e-4c4a-ac41-b31694ff585e",
+  "model_slug": "google/nano-banana-pro",
   "aspect_ratio": "1:1",
-  "resolution": "1080p"
+  "resolution": "2K"
 }
 ```
 
@@ -108,7 +108,7 @@ Use `audio_generation` to skip a separate TTS step:
 ```json
 {
   "type": "video",
-  "ai_model_id": "26f0fc66-152b-40ab-abed-76c43df99bc8",
+  "model_slug": "together/hedra-avatar",
   "start_keyframe_id": "{{ $('Upload Portrait Image').item.json.id }}",
   "audio_generation": {
     "type": "text_to_speech",

--- a/pages/developer/guides/generate-audio.mdx
+++ b/pages/developer/guides/generate-audio.mdx
@@ -59,37 +59,7 @@ curl https://api.hedra.com/web-app/public/generations/{generation_id}/status \
 
 When `status` is `"complete"`, the response includes an `asset_id` for the generated audio file.
 
-## Clone a voice
-
-You can create a custom voice by uploading an audio sample and cloning it.
-
-### 1. Upload an audio sample
-
-```bash
-curl -X POST https://api.hedra.com/web-app/public/assets \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: $HEDRA_API_KEY" \
-  -d '{
-    "name": "voice-sample.mp3",
-    "type": "audio"
-  }'
-
-curl -X POST https://api.hedra.com/web-app/public/assets/{asset_id}/upload \
-  -H "X-API-Key: $HEDRA_API_KEY" \
-  -F "file=@/path/to/voice-sample.mp3"
-```
-
-### 2. Clone the voice
-
-```bash
-curl -X POST https://api.hedra.com/web-app/public/generations \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: $HEDRA_API_KEY" \
-  -d '{
-    "type": "voice_clone",
-    "audio_id": "{audio_asset_id}",
-    "name": "My Custom Voice"
-  }'
-```
-
-Once complete, the response includes an `asset_id` for the new voice. Use this as the `voice_id` in text-to-speech requests.
+<Note>
+  The public generation endpoint currently supports image, video, and
+  text-to-speech requests. Voice cloning is not available through this endpoint.
+</Note>

--- a/pages/developer/guides/generate-avatar-video.mdx
+++ b/pages/developer/guides/generate-avatar-video.mdx
@@ -9,11 +9,15 @@ All examples use the base URL `https://api.hedra.com/web-app/public` and require
 export HEDRA_API_KEY="your_api_key"
 ```
 
-Avatar videos are driven by audio—the character in the image will lip-sync and move to the provided audio. Hedra Avatar (`26f0fc66-152b-40ab-abed-76c43df99bc8`) supports talking-head videos up to 10 minutes and requires an image and audio input.
+Avatar videos are driven by audio—the character in the image will lip-sync and
+move to the provided audio. Hedra Avatar (`together/hedra-avatar`) requires an
+image and audio input. Use `GET /models?types=video` to read its current output
+and input-duration limits before submitting long-form work.
 
 ## Step 1: Upload your audio
 
-The audio determines the video length. For a 10-minute video, provide ~10 minutes of audio.
+The audio normally determines the video length. Omit `duration_ms` to follow the
+source audio.
 
 ```bash
 # Create the asset record
@@ -21,14 +25,14 @@ curl -X POST https://api.hedra.com/web-app/public/assets \
   -H "Content-Type: application/json" \
   -H "X-API-Key: $HEDRA_API_KEY" \
   -d '{
-    "name": "ten-minute-audio.mp3",
+    "name": "avatar-audio.mp3",
     "type": "audio"
   }'
 
 # Upload the file
 curl -X POST https://api.hedra.com/web-app/public/assets/{audio_asset_id}/upload \
   -H "X-API-Key: $HEDRA_API_KEY" \
-  -F "file=@/path/to/ten-minute-audio.mp3"
+  -F "file=@/path/to/avatar-audio.mp3"
 ```
 
 ## Step 2: Upload your portrait image
@@ -49,7 +53,7 @@ curl -X POST https://api.hedra.com/web-app/public/assets/{image_asset_id}/upload
 
 ## Step 3: Generate the avatar video
 
-Use the Hedra Avatar model (`26f0fc66-152b-40ab-abed-76c43df99bc8`):
+Use the Hedra Avatar model (`together/hedra-avatar`):
 
 ```bash
 curl -X POST https://api.hedra.com/web-app/public/generations \
@@ -57,20 +61,20 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
   -H "X-API-Key: $HEDRA_API_KEY" \
   -d '{
     "type": "video",
-    "ai_model_id": "26f0fc66-152b-40ab-abed-76c43df99bc8",
+    "model_slug": "together/hedra-avatar",
     "start_keyframe_id": "{image_asset_id}",
     "audio_id": "{audio_asset_id}",
     "generated_video_inputs": {
       "text_prompt": "A person speaking to the camera",
       "aspect_ratio": "9:16",
-      "resolution": "720p",
-      "duration_ms": 600000
+      "resolution": "720p"
     }
   }'
 ```
 
 <Note>
-  Set `duration_ms` to `600000` for 10 minutes (600 seconds = 600,000 ms). The video duration will match your audio length.
+  The model catalog reports output limits separately from limits on each input
+  slot. Check both before uploading long audio.
 </Note>
 
 ### Inline audio generation
@@ -92,7 +96,7 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
   -H "X-API-Key: $HEDRA_API_KEY" \
   -d '{
     "type": "video",
-    "ai_model_id": "26f0fc66-152b-40ab-abed-76c43df99bc8",
+    "model_slug": "together/hedra-avatar",
     "start_keyframe_id": "{image_asset_id}",
     "audio_generation": {
       "type": "text_to_speech",
@@ -109,7 +113,7 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
 
 ## Step 4: Poll for completion
 
-Long-form avatar videos take longer to generate. Check `progress` (0-1) and `eta_sec` for estimates:
+Avatar videos are asynchronous. Check `progress` (0-1) while polling:
 
 ```bash
 curl https://api.hedra.com/web-app/public/generations/{generation_id}/status \

--- a/pages/developer/guides/generate-image.mdx
+++ b/pages/developer/guides/generate-image.mdx
@@ -18,9 +18,9 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
   -d '{
     "type": "image",
     "text_prompt": "A golden retriever sitting in a field of sunflowers",
-    "ai_model_id": "a66300b4-f76e-4c4a-ac41-b31694ff585e",
+    "model_slug": "google/nano-banana-pro",
     "aspect_ratio": "16:9",
-    "resolution": "1080p"
+    "resolution": "2K"
   }'
 ```
 
@@ -30,16 +30,21 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
 |-------|-------------|
 | `type` | Set to `"image"` |
 | `text_prompt` | The text description of the image to generate |
-| `ai_model_id` | The model to use (see `GET /models` for available image models) |
+| `model_slug` | The model slug to use (see `GET /models?types=image`) |
 
 ### Optional fields
 
 | Field | Description |
 |-------|-------------|
 | `aspect_ratio` | e.g. `"16:9"`, `"9:16"`, `"1:1"` |
-| `resolution` | e.g. `"540p"`, `"720p"`, `"1080p"`, `"1440p (2K QHD)"`, `"2160p (4K UHD)"` |
+| `resolution` | A resolution supported by the selected model |
 | `batch_size` | Generate 1-8 variations at once (default: 1) |
 | `enhance_prompt` | Set to `true` to automatically enhance the prompt |
+
+<Note>
+  When `batch_size` is greater than 1, include a `generation_ids` array containing
+  one client-generated UUID for each variation.
+</Note>
 
 ## Poll for completion
 
@@ -54,9 +59,10 @@ When complete, the response includes an `asset_id` for the generated image.
 
 ## Available image models
 
-Use `GET /models` to list all models. Filter by `"type": "image"` to see image models with their supported resolutions and aspect ratios.
+Use `GET /models?types=image` to list image models and their current slugs,
+supported resolutions, aspect ratios, and input requirements.
 
 ```bash
-curl https://api.hedra.com/web-app/public/models \
+curl "https://api.hedra.com/web-app/public/models?types=image" \
   -H "X-API-Key: $HEDRA_API_KEY"
 ```

--- a/pages/developer/guides/generate-video.mdx
+++ b/pages/developer/guides/generate-video.mdx
@@ -11,7 +11,8 @@ export HEDRA_API_KEY="your_api_key"
 
 ## Text-to-video
 
-Generate a video from a text prompt alone using Grok Video T2V (`827122cd-5fdd-4412-86f2-554f7bb8eef9`):
+Generate a video from a text prompt alone using Grok Video T2V
+(`fal/grok-video-t2v`):
 
 ```bash
 curl -X POST https://api.hedra.com/web-app/public/generations \
@@ -19,7 +20,7 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
   -H "X-API-Key: $HEDRA_API_KEY" \
   -d '{
     "type": "video",
-    "ai_model_id": "827122cd-5fdd-4412-86f2-554f7bb8eef9",
+    "model_slug": "fal/grok-video-t2v",
     "generated_video_inputs": {
       "text_prompt": "A woman walking through a busy market at golden hour",
       "aspect_ratio": "16:9",
@@ -31,7 +32,8 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
 
 ## Image-to-video
 
-Generate a video from a start image using Grok Video I2V (`0435547d-1b30-41ad-bf66-ca476ff0564e`).
+Generate a video from a start image using Grok Video I2V
+(`fal/grok-video-i2v`).
 
 ### Step 1: Upload a start image
 
@@ -59,7 +61,7 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
   -H "X-API-Key: $HEDRA_API_KEY" \
   -d '{
     "type": "video",
-    "ai_model_id": "0435547d-1b30-41ad-bf66-ca476ff0564e",
+    "model_slug": "fal/grok-video-i2v",
     "start_keyframe_id": "{image_asset_id}",
     "generated_video_inputs": {
       "text_prompt": "The scene comes to life with gentle movement",
@@ -81,13 +83,18 @@ curl -X POST https://api.hedra.com/web-app/public/generations \
 
 | Field | Description |
 |-------|-------------|
-| `ai_model_id` | The model to use (see `GET /models` for video models) |
+| `model_slug` | The model slug to use (see `GET /models?types=video`) |
 | `start_keyframe_id` | Asset ID of the start image (required for I2V models) |
 | `end_keyframe_id` | Asset ID of the end image |
 | `generated_video_inputs.aspect_ratio` | e.g. `"16:9"`, `"9:16"`, `"1:1"` |
 | `generated_video_inputs.resolution` | e.g. `"540p"`, `"720p"` |
 | `generated_video_inputs.duration_ms` | Duration in milliseconds |
 | `batch_size` | Generate 1-8 variations at once (default: 1) |
+
+<Note>
+  When `batch_size` is greater than 1, include a `generation_ids` array containing
+  one client-generated UUID for each variation.
+</Note>
 
 ## Poll for completion
 


### PR DESCRIPTION
## Summary
- add a dedicated realtime multiplayer guide under Build with the agent, including email invitations and access roles
- align Library, prompt controls, starter Skills, Space privacy, and Manual tools terminology with the current product
- update API guides and OpenAPI reference to use model slugs and document only supported public generation types

## Validation
- `git diff --check`
- `jq empty docs.json openapi.json`
- `npm exec mintlify@latest broken-links`
- rendered affected Agent and API pages in the local Mintlify preview