### PR TITLE
Polish generated API reference titles

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -13,7 +13,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.OPENAPI_SYNC_TOKEN }}
 
@@ -21,7 +21,7 @@ jobs:
         run: python3 scripts/sync_openapi.py
 
       - name: Open or update the sync pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.OPENAPI_SYNC_TOKEN }}
           branch: automation/sync-v2-openapi

--- a/openapi-overrides.json
+++ b/openapi-overrides.json
@@ -8,42 +8,96 @@
   "paths": {
     "/assets": {
       "get": {
+        "x-mint": {
+          "metadata": {
+            "title": "List Uploaded & Generated Assets",
+            "sidebarTitle": "List Uploaded & Generated Assets"
+          }
+        },
         "description": "Retrieve your uploaded and generated assets by asset type, with optional filtering by IDs."
       },
       "post": {
+        "x-mint": {
+          "metadata": {
+            "title": "Create Asset",
+            "sidebarTitle": "Create Asset"
+          }
+        },
         "description": "Create a new asset record before uploading a supported file to use in generations."
       }
     },
     "/assets/{id}/upload": {
       "post": {
+        "x-mint": {
+          "metadata": {
+            "title": "Upload Asset",
+            "sidebarTitle": "Upload Asset"
+          }
+        },
         "description": "Upload the file contents for a previously created asset."
       }
     },
     "/billing/credits": {
       "get": {
+        "x-mint": {
+          "metadata": {
+            "title": "Get Your Credit Balance",
+            "sidebarTitle": "Get Your Credit Balance"
+          }
+        },
         "description": "Retrieve the current API credit balance for your account."
       }
     },
     "/generations": {
       "get": {
+        "x-mint": {
+          "metadata": {
+            "title": "List Your Generations",
+            "sidebarTitle": "List Your Generations"
+          }
+        },
         "description": "Retrieve a paginated list of your generations, with optional filtering by type, date, or prompt."
       },
       "post": {
+        "x-mint": {
+          "metadata": {
+            "title": "Generate Asset",
+            "sidebarTitle": "Generate Asset"
+          }
+        },
         "description": "Start a new image, video, or audio generation using your chosen model and inputs."
       }
     },
     "/generations/{generation_id}/status": {
       "get": {
+        "x-mint": {
+          "metadata": {
+            "title": "Get Generation Status",
+            "sidebarTitle": "Get Generation Status"
+          }
+        },
         "description": "Check the status of a generation and retrieve the resulting asset when it completes."
       }
     },
     "/models": {
       "get": {
+        "x-mint": {
+          "metadata": {
+            "title": "List Available AI Models",
+            "sidebarTitle": "List Available AI Models"
+          }
+        },
         "description": "Retrieve the list of AI models available through the Hedra API, including image, video, and audio generation models."
       }
     },
     "/voices": {
       "get": {
+        "x-mint": {
+          "metadata": {
+            "title": "List Available Voices",
+            "sidebarTitle": "List Available Voices"
+          }
+        },
         "description": "Retrieve the list of text-to-speech voices available for audio generation and avatar videos."
       }
     }

--- a/openapi.json
+++ b/openapi.json
@@ -70,6 +70,12 @@
             }
           }
         },
+        "x-mint": {
+          "metadata": {
+            "title": "List Available AI Models",
+            "sidebarTitle": "List Available AI Models"
+          }
+        },
         "description": "Retrieve the list of AI models available through the Hedra API, including image, video, and audio generation models."
       }
     },
@@ -101,6 +107,12 @@
             "APIKeyHeader": []
           }
         ],
+        "x-mint": {
+          "metadata": {
+            "title": "List Available Voices",
+            "sidebarTitle": "List Available Voices"
+          }
+        },
         "description": "Retrieve the list of text-to-speech voices available for audio generation and avatar videos."
       }
     },
@@ -168,6 +180,12 @@
             }
           }
         },
+        "x-mint": {
+          "metadata": {
+            "title": "List Uploaded & Generated Assets",
+            "sidebarTitle": "List Uploaded & Generated Assets"
+          }
+        },
         "description": "Retrieve your uploaded and generated assets by asset type, with optional filtering by IDs."
       },
       "post": {
@@ -211,6 +229,12 @@
                 }
               }
             }
+          }
+        },
+        "x-mint": {
+          "metadata": {
+            "title": "Create Asset",
+            "sidebarTitle": "Create Asset"
           }
         },
         "description": "Create a new asset record before uploading a supported file to use in generations."
@@ -270,6 +294,12 @@
                 }
               }
             }
+          }
+        },
+        "x-mint": {
+          "metadata": {
+            "title": "Upload Asset",
+            "sidebarTitle": "Upload Asset"
           }
         },
         "description": "Upload the file contents for a previously created asset."
@@ -425,6 +455,12 @@
             }
           }
         },
+        "x-mint": {
+          "metadata": {
+            "title": "List Your Generations",
+            "sidebarTitle": "List Your Generations"
+          }
+        },
         "description": "Retrieve a paginated list of your generations, with optional filtering by type, date, or prompt."
       },
       "post": {
@@ -574,6 +610,12 @@
             }
           }
         },
+        "x-mint": {
+          "metadata": {
+            "title": "Generate Asset",
+            "sidebarTitle": "Generate Asset"
+          }
+        },
         "description": "Start a new image, video, or audio generation using your chosen model and inputs."
       }
     },
@@ -623,6 +665,12 @@
             }
           }
         },
+        "x-mint": {
+          "metadata": {
+            "title": "Get Generation Status",
+            "sidebarTitle": "Get Generation Status"
+          }
+        },
         "description": "Check the status of a generation and retrieve the resulting asset when it completes."
       }
     },
@@ -650,6 +698,12 @@
             "APIKeyHeader": []
           }
         ],
+        "x-mint": {
+          "metadata": {
+            "title": "Get Your Credit Balance",
+            "sidebarTitle": "Get Your Credit Balance"
+          }
+        },
         "description": "Retrieve the current API credit balance for your account."
       }
     }


### PR DESCRIPTION
## What changed

- Add Mintlify `x-mint.metadata` titles and sidebar titles for all nine generated API operations.
- Preserve the upstream OpenAPI summaries so existing generated routes such as `/api-reference/public/list-assets` remain stable.
- Upgrade `actions/checkout` from v4 to v7 and `peter-evans/create-pull-request` from v7 to v8 for the OpenAPI sync workflow.
- Regenerate `openapi.json` from the source schema plus the documented overrides.

## Why

The generated API reference had regressed to generic operation labels. Updating the OpenAPI summary would improve the labels but also change Mintlify-generated slugs. Mintlify's supported `x-mint.metadata` fields provide polished page and sidebar titles without breaking existing documentation URLs.

The action upgrades also remove the Node 20 deprecation warnings seen during the manual sync run.

## Impact

API reference navigation and page headings are clearer while existing links remain valid. Future automated schema syncs retain these presentation overrides.

## Validation

- `uvx openapi-spec-validator openapi.json`
- Parsed `.github/workflows/sync-openapi.yml` with Ruby YAML
- `git diff --check`
- Visually verified the generated API reference in the local Mintlify preview, including `/api-reference/public/list-assets`
