### PR TITLE
Link API Dashboard anchor directly to /app/settings/api

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -35,7 +35,7 @@
         {
           "anchor": "API Dashboard",
           "icon": "layout-dashboard",
-          "href": "https://www.hedra.com/api-profile"
+          "href": "https://www.hedra.com/app/settings/api"
         }
       ]
     },

--- a/pages/app/getting-started/overview.mdx
+++ b/pages/app/getting-started/overview.mdx
@@ -60,7 +60,7 @@ need them. The difference is where you start:
 
 <Steps>
   <Step title="Create a Space">
-    Open [Hedra](https://hedra.com/app/home) and select **New Space**.
+    Open [Hedra](https://www.hedra.com/app/home) and select **New Space**.
   </Step>
   <Step title="Describe the outcome">
     Start with what you want to accomplish. Add a reference asset, Element, command,


### PR DESCRIPTION
## Why

SE Ranking's 2026-07-24 site audit flags every docs page for "internal links to 3XX": the global **API Dashboard** navbar anchor points at `https://www.hedra.com/api-profile`, which 307-redirects anonymous visitors (crawlers included) into the hosted auth flow.

## Change

Point the anchor at `https://www.hedra.com/app/settings/api` instead — the exact page `/api-profile` forwards to after login, so user-facing behavior is unchanged. Crawlers already skip `/app/settings/*` via the robots.txt disallow (ENG-9162), so the audit warning clears on all docs pages.

Related: hedra-labs/docs#29 (www host for the overview guide's app link), hedra-labs/website#6231 (robots disallow for login-gated marketing CTAs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)