### PR TITLE
Use www host for the app link in the overview guide

### DIFF
--- a/pages/app/getting-started/overview.mdx
+++ b/pages/app/getting-started/overview.mdx
@@ -60,7 +60,7 @@ need them. The difference is where you start:
 
 <Steps>
   <Step title="Create a Space">
-    Open [Hedra](https://hedra.com/app/home) and select **New Space**.
+    Open [Hedra](https://www.hedra.com/app/home) and select **New Space**.
   </Step>
   <Step title="Describe the outcome">
     Start with what you want to accomplish. Add a reference asset, Element, command,


### PR DESCRIPTION
## Why

SE Ranking's 2026-07-24 audit flags docs pages for internal links to redirects. The getting-started overview guide links to `https://hedra.com/app/home` (non-www), which 308-hops to `www` before the auth redirect. It's the only non-www link in the docs — `create-image.mdx` has the identical sentence with the correct host.

## Change

One word: use `https://www.hedra.com/app/home`. Once hedra-labs/website#6231 lands, crawlers skip `/app/home` entirely via robots.txt; this removes the extra redirect hop for real users in the meantime.

Related: hedra-labs/docs#28 (API Dashboard anchor), hedra-labs/website#6231 (robots disallow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)