### PR TITLE
chore: Sync OpenAPI schemas

### DIFF
--- a/openapi-v3.json
+++ b/openapi-v3.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Hedra API v3",
-    "description": "Every leading image, video, and audio model behind one endpoint, one key, and one bill. Browse the [model catalog](https://www.hedra.com/develop/models), then ship with the same key.\n\n**Authenticate** every request with your API key \u2014 create one in the [developer console](https://www.hedra.com/develop/api-keys): `Authorization: Key <key_id>:<secret>`.\n\n**Quickstart** \u2014 submit a job, poll it, then read the output URL:\n\n```bash\n# 1. Submit \u2014 capture the job id from the 202 ack\nJOB_ID=$(curl -sS -X POST https://api.hedra.com/v3/models/gpt-image-2 \\\n  -H \"Authorization: Key $HEDRA_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input\": {\"prompt\": \"a space cat\", \"quality\": \"medium\", \"aspect_ratio\": \"1:1\", \"resolution\": \"1K\"}}' | jq -r .job_id)\n\n# 2. Poll until status is COMPLETED (or FAILED)\ncurl https://api.hedra.com/v3/jobs/$JOB_ID/status -H \"Authorization: Key $HEDRA_KEY\"\n\n# 3. Read the result \u2014 outputs[].url holds the generated file\ncurl https://api.hedra.com/v3/jobs/$JOB_ID -H \"Authorization: Key $HEDRA_KEY\"\n```\n\n**Find a model** \u2014 `GET /models` lists every model with its `id` and human `name`; each operation in the *Run a model* section is titled with both, so a model you know by name (\"GPT Image 2\") maps straight to the id you submit to (`gpt-image-2`). One model's typed input schema: `GET /models/{id}/openapi.json`.\n\nEstimate cost before you run with `POST /models/{model}/estimate`, and check your balance at `GET /balance`. For volume pricing and custom limits, [talk to us](https://www.hedra.com/enterprise).\n\nThe full machine-readable spec is at `https://api.hedra.com/v3/openapi.json`.",
+    "description": "Every leading image, video, and audio model behind one endpoint, one key, and one bill. Browse the [model catalog](https://www.hedra.com/develop/models), then ship with the same key.\n\n**Authenticate** every request with your API key \u2014 create one in the [developer console](https://www.hedra.com/develop/api-keys): `Authorization: Key <key_id>:<secret>`.\n\n**Fund the API wallet** before your first call \u2014 this is the one bill, and it is prepaid. It is held in US dollars, it is separate from your Hedra Studio balance, and a workspace starts with **$0.00** in it; nothing you buy or hold in Studio moves money into it. Until it is funded, every generation is refused with `402 INSUFFICIENT_BALANCE`; uploading inputs with `POST /files` is free and works on an empty wallet, so you can stage a request and only meet the gate at submit. Add funds in the [developer console](https://www.hedra.com/develop/billing), and read the wallet any time with `GET /balance`.\n\n**Quickstart** \u2014 submit a job, poll it, then read the output URL:\n\n```bash\n# 1. Submit \u2014 capture the job id from the 202 ack\nJOB_ID=$(curl -sS -X POST https://api.hedra.com/v3/models/gpt-image-2 \\\n  -H \"Authorization: Key $HEDRA_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input\": {\"prompt\": \"a space cat\", \"quality\": \"medium\", \"aspect_ratio\": \"1:1\", \"resolution\": \"1K\"}}' | jq -r .job_id)\n\n# 2. Poll until status is COMPLETED (or FAILED)\ncurl https://api.hedra.com/v3/jobs/$JOB_ID/status -H \"Authorization: Key $HEDRA_KEY\"\n\n# 3. Read the result \u2014 outputs[].url holds the generated file\ncurl https://api.hedra.com/v3/jobs/$JOB_ID -H \"Authorization: Key $HEDRA_KEY\"\n```\n\n**Find a model** \u2014 `GET /models` lists every model with its `id` and human `name`; each operation in the *Run a model* section is titled with both, so a model you know by name (\"GPT Image 2\") maps straight to the id you submit to (`gpt-image-2`). One model's typed input schema: `GET /models/{id}/openapi.json`.\n\nEstimate cost before you run with `POST /models/{model}/estimate`. For volume pricing and custom limits, [talk to us](https://www.hedra.com/enterprise).\n\nThe full machine-readable spec is at `https://api.hedra.com/v3/openapi.json`.",
     "version": "3.0.0"
   },
   "servers": [
@@ -27,9 +27,11 @@
               "type": "integer",
               "maximum": 100,
               "minimum": 1,
+              "description": "Maximum items per page.",
               "default": 20,
               "title": "Limit"
-            }
+            },
+            "description": "Maximum items per page."
           },
           {
             "name": "cursor",
@@ -44,8 +46,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page.",
               "title": "Cursor"
-            }
+            },
+            "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page."
           }
         ],
         "responses": {
@@ -314,8 +318,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The job's id (`job_<uuid>`).",
               "title": "Job Id"
-            }
+            },
+            "description": "The job's id (`job_<uuid>`)."
           }
         ],
         "responses": {
@@ -584,8 +590,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The job's id (`job_<uuid>`).",
               "title": "Job Id"
-            }
+            },
+            "description": "The job's id (`job_<uuid>`)."
           },
           {
             "name": "logs_after",
@@ -872,8 +880,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The job's id (`job_<uuid>`).",
               "title": "Job Id"
-            }
+            },
+            "description": "The job's id (`job_<uuid>`)."
           },
           {
             "name": "limit",
@@ -883,9 +893,11 @@
               "type": "integer",
               "maximum": 100,
               "minimum": 1,
+              "description": "Maximum items per page.",
               "default": 20,
               "title": "Limit"
-            }
+            },
+            "description": "Maximum items per page."
           },
           {
             "name": "cursor",
@@ -900,8 +912,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page.",
               "title": "Cursor"
-            }
+            },
+            "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page."
           }
         ],
         "responses": {
@@ -1170,8 +1184,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The job's id (`job_<uuid>`).",
               "title": "Job Id"
-            }
+            },
+            "description": "The job's id (`job_<uuid>`)."
           },
           {
             "name": "Last-Event-Id",
@@ -1186,8 +1202,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Resume after this event id \u2014 the standard SSE reconnect header; browsers' EventSource sends it automatically.",
               "title": "Last-Event-Id"
-            }
+            },
+            "description": "Resume after this event id \u2014 the standard SSE reconnect header; browsers' EventSource sends it automatically."
           }
         ],
         "responses": {
@@ -1693,8 +1711,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The model's public id (`GET /v3/models`).",
               "title": "Model"
-            }
+            },
+            "description": "The model's public id (`GET /v3/models`)."
           }
         ],
         "responses": {
@@ -1923,8 +1943,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The model's public id (`GET /v3/models`).",
               "title": "Model"
-            }
+            },
+            "description": "The model's public id (`GET /v3/models`)."
           },
           {
             "name": "limit",
@@ -1934,9 +1956,11 @@
               "type": "integer",
               "maximum": 100,
               "minimum": 1,
+              "description": "Maximum items per page.",
               "default": 20,
               "title": "Limit"
-            }
+            },
+            "description": "Maximum items per page."
           },
           {
             "name": "cursor",
@@ -1951,8 +1975,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page.",
               "title": "Cursor"
-            }
+            },
+            "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page."
           }
         ],
         "responses": {
@@ -2222,8 +2248,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The model's public id (`GET /v3/models`).",
               "title": "Model"
-            }
+            },
+            "description": "The model's public id (`GET /v3/models`)."
           }
         ],
         "responses": {
@@ -2453,8 +2481,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The model's public id (`GET /v3/models`).",
               "title": "Model"
-            }
+            },
+            "description": "The model's public id (`GET /v3/models`)."
           }
         ],
         "responses": {
@@ -2685,8 +2715,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The model's public id (`GET /v3/models`).",
               "title": "Model"
-            }
+            },
+            "description": "The model's public id (`GET /v3/models`)."
           }
         ],
         "requestBody": {
@@ -3239,8 +3271,10 @@
                   "type": "null"
                 }
               ],
+              "description": "List keys of this workspace; omitted means the authenticating key's workspace.",
               "title": "Workspace Id"
-            }
+            },
+            "description": "List keys of this workspace; omitted means the authenticating key's workspace."
           }
         ],
         "responses": {
@@ -3509,8 +3543,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The key's public identifier.",
               "title": "Key Id"
-            }
+            },
+            "description": "The key's public identifier."
           }
         ],
         "requestBody": {
@@ -3789,8 +3825,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The key's public identifier.",
               "title": "Key Id"
-            }
+            },
+            "description": "The key's public identifier."
           }
         ],
         "responses": {
@@ -4313,6 +4351,7 @@
           "Access"
         ],
         "summary": "Upload File",
+        "description": "Store a file and return a short-lived URL to pass in a model's `input`.\n\nFree, and available on an empty API wallet \u2014 funding is enforced when you\nsubmit a generation, not when you upload its inputs. `GET /v3/balance`\nreports what the wallet holds.",
         "operationId": "files_upload",
         "responses": {
           "201": {
@@ -4867,8 +4906,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Window start (inclusive, ISO-8601); defaults to 7 days before `end`. Bounds job-creation time.",
               "title": "Start"
-            }
+            },
+            "description": "Window start (inclusive, ISO-8601); defaults to 7 days before `end`. Bounds job-creation time."
           },
           {
             "name": "end",
@@ -4884,8 +4925,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Window end (exclusive, ISO-8601); defaults to now. The window is capped at 90 days.",
               "title": "End"
-            }
+            },
+            "description": "Window end (exclusive, ISO-8601); defaults to now. The window is capped at 90 days."
           },
           {
             "name": "group_by",
@@ -4893,8 +4936,10 @@
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/UsageGroupBy",
+              "description": "One summary row (`total`), one per UTC day (`day`), or one per model (`model`).",
               "default": "total"
-            }
+            },
+            "description": "One summary row (`total`), one per UTC day (`day`), or one per model (`model`)."
           }
         ],
         "responses": {
@@ -6419,9 +6464,11 @@
               "type": "integer",
               "maximum": 100,
               "minimum": 1,
+              "description": "Maximum items per page.",
               "default": 20,
               "title": "Limit"
-            }
+            },
+            "description": "Maximum items per page."
           },
           {
             "name": "cursor",
@@ -6436,8 +6483,10 @@
                   "type": "null"
                 }
               ],
+              "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page.",
               "title": "Cursor"
-            }
+            },
+            "description": "Opaque cursor from the previous page's `next_cursor`; omit for the first page."
           }
         ],
         "responses": {
@@ -6707,8 +6756,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The job's id (`job_<uuid>`).",
               "title": "Job Id"
-            }
+            },
+            "description": "The job's id (`job_<uuid>`)."
           }
         ],
         "responses": {
@@ -7503,8 +7554,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The drain's id (`drain_<uuid>`).",
               "title": "Drain Id"
-            }
+            },
+            "description": "The drain's id (`drain_<uuid>`)."
           }
         ],
         "responses": {
@@ -7771,8 +7824,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The drain's id (`drain_<uuid>`).",
               "title": "Drain Id"
-            }
+            },
+            "description": "The drain's id (`drain_<uuid>`)."
           }
         ],
         "requestBody": {
@@ -8049,8 +8104,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The drain's id (`drain_<uuid>`).",
               "title": "Drain Id"
-            }
+            },
+            "description": "The drain's id (`drain_<uuid>`)."
           }
         ],
         "responses": {
@@ -8312,8 +8369,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "The drain's id (`drain_<uuid>`).",
               "title": "Drain Id"
-            }
+            },
+            "description": "The drain's id (`drain_<uuid>`)."
           }
         ],
         "responses": {
@@ -8700,6 +8759,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -8993,6 +9095,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -9300,6 +9445,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -9593,6 +9781,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -9900,6 +10131,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -10193,6 +10467,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -10500,6 +10817,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -10793,6 +11153,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -11100,6 +11503,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -11393,6 +11839,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -11700,6 +12189,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -11993,6 +12525,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -12300,6 +12875,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -12593,6 +13211,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -12900,6 +13561,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -13193,6 +13897,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -13500,6 +14247,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -13793,6 +14583,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -14100,6 +14933,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -14393,6 +15269,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -14700,6 +15619,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -14993,6 +15955,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -15300,6 +16305,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -15593,6 +16641,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -15900,6 +16991,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -16193,6 +17327,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -16500,6 +17677,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -16793,6 +18013,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -17100,6 +18363,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -17393,6 +18699,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -17700,6 +19049,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -17993,6 +19385,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -18300,6 +19735,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -18593,6 +20071,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -18900,6 +20421,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -19193,6 +20757,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -19500,6 +21107,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -19793,6 +21443,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -20100,6 +21793,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -20393,6 +22129,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -20700,6 +22479,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -20993,6 +22815,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -21300,6 +23165,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -21593,6 +23501,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -21900,6 +23851,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -22193,6 +24187,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -22500,6 +24537,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -22793,6 +24873,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -23100,6 +25223,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -23393,6 +25559,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -23700,6 +25909,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -23993,6 +26245,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -24300,6 +26595,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -24593,6 +26931,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -24900,6 +27281,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -25193,6 +27617,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -25500,6 +27967,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -25793,6 +28303,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -26100,6 +28653,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -26393,6 +28989,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -26700,6 +29339,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -26993,6 +29675,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -27300,6 +30025,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -27593,6 +30361,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -27900,6 +30711,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -28193,6 +31047,49 @@
                         "code": "UNAUTHORIZED",
                         "message": "Invalid API key.",
                         "retryable": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
                       }
                     }
                   }
@@ -28500,6 +31397,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -28800,6 +31740,49 @@
               }
             }
           },
+          "402": {
+            "description": "The API wallet cannot cover this request. `error.billing` carries the balance, the price, and where to add funds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "unfunded_submit": {
+                    "summary": "The API wallet cannot pay for this job",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00 and this request costs $0.05. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "required": 0.05,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  },
+                  "unquotable_submit": {
+                    "summary": "The model cannot be priced before its inputs are measured, so `required` is null",
+                    "value": {
+                      "error": {
+                        "code": "INSUFFICIENT_BALANCE",
+                        "message": "Your API wallet balance is $0.00. The API wallet is funded separately from Studio and pays only for API requests \u2014 add funds at https://www.hedra.com/develop/billing, then retry.",
+                        "retryable": false,
+                        "billing": {
+                          "balance": 0.0,
+                          "currency": "USD",
+                          "funding_url": "https://www.hedra.com/develop/billing?add_funds=true"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "403": {
             "description": "Insufficient scope or plan.",
             "content": {
@@ -29028,6 +32011,45 @@
         "title": "BalanceResponse",
         "description": "Spendable balance on the account this key bills.\n\nSourced from the workspace wallet for a workspace-bound key, else the\ncaller's personal balance. While the segregated API wallet is enabled, both\nkey types instead read the API wallet that generation debits draw on (a\npersonal key resolves its bound workspace).\n\nEvery amount is in US dollars."
       },
+      "BillingError": {
+        "properties": {
+          "balance": {
+            "type": "number",
+            "title": "Balance",
+            "description": "Spendable balance on the account this request bills, at the moment it was refused. The same value `GET /balance` returns."
+          },
+          "required": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Required",
+            "description": "What this request needed. Null when the refusal is a funding precondition rather than a priced one \u2014 an upload is not priced, and some models cannot be quoted until their inputs are measured (`POST /models/{model}/estimate` says so explicitly)."
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency",
+            "description": "ISO-4217 code the amounts above are denominated in.",
+            "default": "USD"
+          },
+          "funding_url": {
+            "type": "string",
+            "title": "Funding Url",
+            "description": "Where a human can add funds to the account this request bills. The API itself cannot add them."
+          }
+        },
+        "type": "object",
+        "required": [
+          "balance",
+          "funding_url"
+        ],
+        "title": "BillingError",
+        "description": "Why a request was refused for funds, and what would clear it.\n\nThe envelope's structured detail for `INSUFFICIENT_BALANCE`, the way\n`details` is its structured detail for a validation failure. Every amount is\nin `currency`, and `balance` is the same number `GET /balance` returns \u2014 so\na client can decide whether to top up, wait, or fail over without a second\nround trip to work out which balance was short."
+      },
       "ErrorCode": {
         "type": "string",
         "enum": [
@@ -29057,11 +32079,13 @@
           },
           "message": {
             "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "description": "Human-readable summary of the error. Fixed per condition \u2014 match on `code`, not on this text."
           },
           "retryable": {
             "type": "boolean",
             "title": "Retryable",
+            "description": "Whether retrying the same request can succeed. Describes the condition, not a promise \u2014 pair with `retry_after` when present.",
             "default": false
           },
           "retry_after": {
@@ -29073,7 +32097,8 @@
                 "type": "null"
               }
             ],
-            "title": "Retry After"
+            "title": "Retry After",
+            "description": "Seconds to wait before retrying; set when the error is retryable. Mirrors the `Retry-After` response header."
           },
           "param": {
             "anyOf": [
@@ -29084,7 +32109,8 @@
                 "type": "null"
               }
             ],
-            "title": "Param"
+            "title": "Param",
+            "description": "The primary offending input field, when the error is about one specific field."
           },
           "details": {
             "anyOf": [
@@ -29098,7 +32124,8 @@
                 "type": "null"
               }
             ],
-            "title": "Details"
+            "title": "Details",
+            "description": "Every field-level problem, when the error is a validation failure \u2014 all of them at once, not just the first."
           },
           "replaced_by": {
             "anyOf": [
@@ -29109,7 +32136,19 @@
                 "type": "null"
               }
             ],
-            "title": "Replaced By"
+            "title": "Replaced By",
+            "description": "The id of a successor model, set when the requested model has been retired (code `GONE`) and replaced; null otherwise. Lets a client programmatically migrate off a retired model."
+          },
+          "billing": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BillingError"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Balance, price, and where to add funds \u2014 set when the request was refused for funds (code `INSUFFICIENT_BALANCE`); null otherwise."
           }
         },
         "type": "object",
@@ -29133,7 +32172,8 @@
                 "type": "null"
               }
             ],
-            "title": "Trace Id"
+            "title": "Trace Id",
+            "description": "Debug id to quote to support (32-char hex trace id), also emitted as the `X-Trace-Id` response header."
           }
         },
         "type": "object",
@@ -29148,7 +32188,8 @@
           "input": {
             "additionalProperties": true,
             "type": "object",
-            "title": "Input"
+            "title": "Input",
+            "description": "The same model-specific inputs a submit would carry; the estimate prices exactly this body."
           }
         },
         "type": "object",
@@ -29158,7 +32199,8 @@
         "properties": {
           "model": {
             "type": "string",
-            "title": "Model"
+            "title": "Model",
+            "description": "The resolved model id this estimate prices."
           },
           "cost": {
             "type": "number",
@@ -29184,11 +32226,13 @@
         "properties": {
           "field": {
             "type": "string",
-            "title": "Field"
+            "title": "Field",
+            "description": "Dotted path to the offending input (e.g. `input.resolution`)."
           },
           "message": {
             "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "description": "What is wrong with this field's value."
           },
           "reason": {
             "anyOf": [
@@ -29199,7 +32243,8 @@
                 "type": "null"
               }
             ],
-            "title": "Reason"
+            "title": "Reason",
+            "description": "Machine-readable hint for which constraint failed (\"required\", \"enum\", \"type\", \u2026)."
           },
           "allowed": {
             "anyOf": [
@@ -29213,7 +32258,8 @@
                 "type": "null"
               }
             ],
-            "title": "Allowed"
+            "title": "Allowed",
+            "description": "The accepted values, when the field is an enum \u2014 so the request can be fixed without re-fetching the model schema."
           }
         },
         "type": "object",
@@ -29259,7 +32305,8 @@
               "$ref": "#/components/schemas/JobSummary"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "This page of items."
           },
           "next_cursor": {
             "anyOf": [
@@ -29303,12 +32350,14 @@
         "properties": {
           "id": {
             "type": "integer",
-            "title": "Id"
+            "title": "Id",
+            "description": "Monotonically increasing id of this event within the job's log. Cursors are separate opaque values (`next_cursor` / `logs_next_cursor`); do not send this id as one."
           },
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "description": "ISO-8601 instant the event was recorded."
           },
           "level": {
             "$ref": "#/components/schemas/JobLogLevel"
@@ -29318,7 +32367,8 @@
           },
           "message": {
             "type": "string",
-            "title": "Message"
+            "title": "Message",
+            "description": "Human-readable summary of the event."
           },
           "source": {
             "$ref": "#/components/schemas/JobLogSource"
@@ -29326,7 +32376,8 @@
           "data": {
             "additionalProperties": true,
             "type": "object",
-            "title": "Data"
+            "title": "Data",
+            "description": "Structured detail specific to this event type; empty when the event carries none."
           }
         },
         "type": "object",
@@ -29357,7 +32408,8 @@
               "$ref": "#/components/schemas/JobLogItem"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "This page of items."
           },
           "next_cursor": {
             "anyOf": [
@@ -29404,11 +32456,13 @@
         "properties": {
           "job_id": {
             "type": "string",
-            "title": "Job Id"
+            "title": "Job Id",
+            "description": "The job's id \u2014 server-issued, and opaque."
           },
           "model": {
             "type": "string",
-            "title": "Model"
+            "title": "Model",
+            "description": "The resolved model id this job ran on."
           },
           "quality": {
             "anyOf": [
@@ -29428,7 +32482,8 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "description": "ISO-8601 instant the job was submitted."
           }
         },
         "type": "object",
@@ -29451,7 +32506,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable label for the key."
           },
           "scopes": {
             "anyOf": [
@@ -29465,10 +32521,12 @@
                 "type": "null"
               }
             ],
-            "title": "Scopes"
+            "title": "Scopes",
+            "description": "Scopes granted to the key; omitted means full access."
           },
           "kind": {
             "$ref": "#/components/schemas/ApiKeyKind",
+            "description": "`personal` (default) dies with the member; `service` is workspace-shared, OWNER/ADMIN-managed, and survives member removal.",
             "default": "personal"
           },
           "workspace_id": {
@@ -29480,7 +32538,8 @@
                 "type": "null"
               }
             ],
-            "title": "Workspace Id"
+            "title": "Workspace Id",
+            "description": "Target workspace; omitted means the authenticating key's workspace."
           },
           "expires_at": {
             "anyOf": [
@@ -29492,7 +32551,8 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "description": "ISO-8601 instant the key stops authenticating; omitted means it never expires."
           }
         },
         "type": "object",
@@ -29502,11 +32562,13 @@
         "properties": {
           "key_id": {
             "type": "string",
-            "title": "Key Id"
+            "title": "Key Id",
+            "description": "The key's public identifier."
           },
           "credential": {
             "type": "string",
-            "title": "Credential"
+            "title": "Credential",
+            "description": "The full `<key_id>:<secret>` pair \u2014 a valid Bearer credential. Returned exactly once, at creation; store it now."
           },
           "kind": {
             "$ref": "#/components/schemas/ApiKeyKind"
@@ -29520,7 +32582,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable label for the key."
           },
           "scopes": {
             "anyOf": [
@@ -29534,7 +32597,8 @@
                 "type": "null"
               }
             ],
-            "title": "Scopes"
+            "title": "Scopes",
+            "description": "Scopes granted to the key; null means full access (a legacy key predating scopes)."
           },
           "workspace_id": {
             "anyOf": [
@@ -29545,7 +32609,8 @@
                 "type": "null"
               }
             ],
-            "title": "Workspace Id"
+            "title": "Workspace Id",
+            "description": "The workspace the key bills and acts in."
           },
           "expires_at": {
             "anyOf": [
@@ -29557,7 +32622,8 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "description": "ISO-8601 instant the key stops authenticating; null means it never expires."
           },
           "created_at": {
             "anyOf": [
@@ -29569,7 +32635,8 @@
                 "type": "null"
               }
             ],
-            "title": "Created At"
+            "title": "Created At",
+            "description": "ISO-8601 instant the key was created."
           }
         },
         "type": "object",
@@ -29587,7 +32654,8 @@
               "$ref": "#/components/schemas/KeySummary"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "This page of items."
           },
           "next_cursor": {
             "anyOf": [
@@ -29621,7 +32689,8 @@
                 "type": "null"
               }
             ],
-            "title": "Grace Period Seconds"
+            "title": "Grace Period Seconds",
+            "description": "Seconds the old secret keeps authenticating after the rotation; omitted means the service default (24h)."
           }
         },
         "type": "object",
@@ -29631,11 +32700,13 @@
         "properties": {
           "key_id": {
             "type": "string",
-            "title": "Key Id"
+            "title": "Key Id",
+            "description": "The key's public identifier \u2014 unchanged by rotation."
           },
           "credential": {
             "type": "string",
-            "title": "Credential"
+            "title": "Credential",
+            "description": "The new `<key_id>:<secret>` pair \u2014 a valid Bearer credential, shown exactly once, like at create."
           },
           "kind": {
             "$ref": "#/components/schemas/ApiKeyKind"
@@ -29649,7 +32720,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable label for the key."
           },
           "scopes": {
             "anyOf": [
@@ -29663,7 +32735,8 @@
                 "type": "null"
               }
             ],
-            "title": "Scopes"
+            "title": "Scopes",
+            "description": "Scopes granted to the key; null means full access (a legacy key predating scopes)."
           },
           "workspace_id": {
             "anyOf": [
@@ -29674,7 +32747,8 @@
                 "type": "null"
               }
             ],
-            "title": "Workspace Id"
+            "title": "Workspace Id",
+            "description": "The workspace the key bills and acts in."
           },
           "expires_at": {
             "anyOf": [
@@ -29686,7 +32760,8 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "description": "ISO-8601 instant the key stops authenticating; null means it never expires."
           },
           "previous_secret_expires_at": {
             "anyOf": [
@@ -29698,7 +32773,8 @@
                 "type": "null"
               }
             ],
-            "title": "Previous Secret Expires At"
+            "title": "Previous Secret Expires At",
+            "description": "ISO-8601 instant the previous secret stops authenticating \u2014 the end of the grace window."
           }
         },
         "type": "object",
@@ -29729,7 +32805,8 @@
                 "type": "null"
               }
             ],
-            "title": "Key Id"
+            "title": "Key Id",
+            "description": "The key's public identifier; null only for legacy rows predating public key ids."
           },
           "kind": {
             "$ref": "#/components/schemas/ApiKeyKind"
@@ -29743,7 +32820,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable label for the key."
           },
           "scopes": {
             "anyOf": [
@@ -29757,7 +32835,8 @@
                 "type": "null"
               }
             ],
-            "title": "Scopes"
+            "title": "Scopes",
+            "description": "Scopes granted to the key; null means full access (a legacy key predating scopes)."
           },
           "workspace_id": {
             "anyOf": [
@@ -29768,7 +32847,8 @@
                 "type": "null"
               }
             ],
-            "title": "Workspace Id"
+            "title": "Workspace Id",
+            "description": "The workspace the key bills and acts in."
           },
           "status": {
             "$ref": "#/components/schemas/KeyStatus"
@@ -29783,7 +32863,8 @@
                 "type": "null"
               }
             ],
-            "title": "Created At"
+            "title": "Created At",
+            "description": "ISO-8601 instant the key was created."
           },
           "expires_at": {
             "anyOf": [
@@ -29795,7 +32876,8 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "description": "ISO-8601 instant the key stops authenticating; null means it never expires."
           },
           "revoked_at": {
             "anyOf": [
@@ -29807,7 +32889,8 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "description": "ISO-8601 instant the key was revoked; null unless `status` is `revoked`."
           },
           "last_used_at": {
             "anyOf": [
@@ -29819,7 +32902,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Used At"
+            "title": "Last Used At",
+            "description": "ISO-8601 instant the key last authenticated a request; null when unused."
           }
         },
         "type": "object",
@@ -29834,15 +32918,18 @@
         "properties": {
           "id": {
             "type": "string",
-            "title": "Id"
+            "title": "Id",
+            "description": "The drain's id (`drain_<uuid>`)."
           },
           "name": {
             "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable label."
           },
           "url": {
             "type": "string",
-            "title": "Url"
+            "title": "Url",
+            "description": "The destination endpoint."
           },
           "format": {
             "$ref": "#/components/schemas/LogDrainFormat"
@@ -29852,19 +32939,23 @@
               "type": "string"
             },
             "type": "array",
-            "title": "Header Names"
+            "title": "Header Names",
+            "description": "Names of the configured extra headers. Values are write-only and never echoed back."
           },
           "enabled": {
             "type": "boolean",
-            "title": "Enabled"
+            "title": "Enabled",
+            "description": "Whether the drain receives batches."
           },
           "batch_size": {
             "type": "integer",
-            "title": "Batch Size"
+            "title": "Batch Size",
+            "description": "Maximum log lines per post."
           },
           "consecutive_failures": {
             "type": "integer",
-            "title": "Consecutive Failures"
+            "title": "Consecutive Failures",
+            "description": "Failed batches since the last success; the drain auto-disables when it crosses the failure threshold."
           },
           "last_success_at": {
             "anyOf": [
@@ -29876,7 +32967,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Success At"
+            "title": "Last Success At",
+            "description": "ISO-8601 instant of the last delivered batch."
           },
           "last_failure_at": {
             "anyOf": [
@@ -29888,7 +32980,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Failure At"
+            "title": "Last Failure At",
+            "description": "ISO-8601 instant of the last failed batch."
           },
           "last_failure_status": {
             "anyOf": [
@@ -29899,7 +32992,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Failure Status"
+            "title": "Last Failure Status",
+            "description": "HTTP status of the last failed batch; null when it never got a response."
           },
           "last_error": {
             "anyOf": [
@@ -29921,17 +33015,20 @@
                 "type": "null"
               }
             ],
-            "title": "Disabled Reason"
+            "title": "Disabled Reason",
+            "description": "Why the drain is off (`consecutive_failures` for auto-disable, `disabled_by_user`); null while enabled."
           },
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "description": "ISO-8601 instant the drain was created."
           },
           "updated_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Updated At"
+            "title": "Updated At",
+            "description": "ISO-8601 instant the config last changed."
           },
           "updated_by_key_id": {
             "anyOf": [
@@ -29942,7 +33039,8 @@
                 "type": "null"
               }
             ],
-            "title": "Updated By Key Id"
+            "title": "Updated By Key Id",
+            "description": "The API key that last changed the config."
           }
         },
         "type": "object",
@@ -29988,13 +33086,15 @@
             "type": "string",
             "maxLength": 100,
             "minLength": 1,
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable label."
           },
           "url": {
             "type": "string",
             "maxLength": 8192,
             "minLength": 1,
-            "title": "Url"
+            "title": "Url",
+            "description": "HTTPS endpoint job-log batches are posted to."
           },
           "format": {
             "$ref": "#/components/schemas/LogDrainFormat",
@@ -30030,11 +33130,13 @@
               }
             ],
             "title": "Headers",
+            "description": "Extra headers sent with every post \u2014 typically the receiver's authentication. Stored values are never echoed back; reads expose `header_names` only.",
             "writeOnly": true
           },
           "enabled": {
             "type": "boolean",
             "title": "Enabled",
+            "description": "Whether the drain receives batches.",
             "default": true
           },
           "batch_size": {
@@ -30042,6 +33144,7 @@
             "maximum": 5000.0,
             "minimum": 1.0,
             "title": "Batch Size",
+            "description": "Maximum log lines per post.",
             "default": 1000
           }
         },
@@ -30068,7 +33171,8 @@
               "$ref": "#/components/schemas/LogDrainConfig"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "This page of items."
           },
           "next_cursor": {
             "anyOf": [
@@ -30094,7 +33198,8 @@
         "properties": {
           "ok": {
             "type": "boolean",
-            "title": "Ok"
+            "title": "Ok",
+            "description": "Whether the test batch got a 2xx from the endpoint."
           },
           "response_status": {
             "anyOf": [
@@ -30105,7 +33210,8 @@
                 "type": "null"
               }
             ],
-            "title": "Response Status"
+            "title": "Response Status",
+            "description": "HTTP status the endpoint returned; null when the request never got a response."
           },
           "error": {
             "anyOf": [
@@ -30116,7 +33222,8 @@
                 "type": "null"
               }
             ],
-            "title": "Error"
+            "title": "Error",
+            "description": "Why the test failed; null on success."
           }
         },
         "type": "object",
@@ -30138,7 +33245,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "New label; omitted means unchanged."
           },
           "url": {
             "anyOf": [
@@ -30151,7 +33259,8 @@
                 "type": "null"
               }
             ],
-            "title": "Url"
+            "title": "Url",
+            "description": "New destination; omitted means unchanged."
           },
           "format": {
             "anyOf": [
@@ -30161,7 +33270,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "New wire format; omitted means unchanged."
           },
           "secret": {
             "anyOf": [
@@ -30193,6 +33303,7 @@
               }
             ],
             "title": "Headers",
+            "description": "Replaces the full header set; `{}` clears it. Omitted means unchanged.",
             "writeOnly": true
           },
           "enabled": {
@@ -30204,7 +33315,8 @@
                 "type": "null"
               }
             ],
-            "title": "Enabled"
+            "title": "Enabled",
+            "description": "Pause (false) or resume (true) the drain; omitted means unchanged. Re-enabling clears the auto-disable failure count."
           },
           "batch_size": {
             "anyOf": [
@@ -30217,7 +33329,8 @@
                 "type": "null"
               }
             ],
-            "title": "Batch Size"
+            "title": "Batch Size",
+            "description": "New maximum log lines per post; omitted means unchanged."
           }
         },
         "type": "object",
@@ -30256,7 +33369,8 @@
         "properties": {
           "id": {
             "type": "string",
-            "title": "Id"
+            "title": "Id",
+            "description": "The model's public id \u2014 the value POST /v3/models/{model} takes."
           },
           "modality": {
             "$ref": "#/components/schemas/Modality"
@@ -30270,7 +33384,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable name."
           },
           "description": {
             "anyOf": [
@@ -30281,7 +33396,8 @@
                 "type": "null"
               }
             ],
-            "title": "Description"
+            "title": "Description",
+            "description": "One-line summary of what the model does."
           },
           "logo_url": {
             "anyOf": [
@@ -30292,17 +33408,20 @@
                 "type": "null"
               }
             ],
-            "title": "Logo Url"
+            "title": "Logo Url",
+            "description": "URL of the provider's logo."
           },
           "input_schema": {
             "additionalProperties": true,
             "type": "object",
-            "title": "Input Schema"
+            "title": "Input Schema",
+            "description": "JSON Schema for this model's `input` object on submit \u2014 the same schema `GET /v3/models/{model}/openapi.json` embeds."
           },
           "output_schema": {
             "additionalProperties": true,
             "type": "object",
-            "title": "Output Schema"
+            "title": "Output Schema",
+            "description": "JSON Schema of one item of a completed job's `outputs[]`."
           }
         },
         "type": "object",
@@ -30319,7 +33438,8 @@
               "$ref": "#/components/schemas/ModelSummary"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "This page of items."
           },
           "next_cursor": {
             "anyOf": [
@@ -30345,7 +33465,8 @@
         "properties": {
           "id": {
             "type": "string",
-            "title": "Id"
+            "title": "Id",
+            "description": "The model's public id \u2014 the value POST /v3/models/{model} takes."
           },
           "modality": {
             "$ref": "#/components/schemas/Modality"
@@ -30359,7 +33480,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable name."
           },
           "description": {
             "anyOf": [
@@ -30370,7 +33492,8 @@
                 "type": "null"
               }
             ],
-            "title": "Description"
+            "title": "Description",
+            "description": "One-line summary of what the model does."
           },
           "logo_url": {
             "anyOf": [
@@ -30381,7 +33504,8 @@
                 "type": "null"
               }
             ],
-            "title": "Logo Url"
+            "title": "Logo Url",
+            "description": "URL of the provider's logo."
           }
         },
         "type": "object",
@@ -30419,7 +33543,8 @@
               }
             ],
             "format": "uri",
-            "title": "Url"
+            "title": "Url",
+            "description": "Presigned download URL for the output bytes. Null once the output has expired."
           },
           "content_type": {
             "anyOf": [
@@ -30430,7 +33555,8 @@
                 "type": "null"
               }
             ],
-            "title": "Content Type"
+            "title": "Content Type",
+            "description": "MIME type of the output bytes."
           },
           "width": {
             "anyOf": [
@@ -30441,7 +33567,8 @@
                 "type": "null"
               }
             ],
-            "title": "Width"
+            "title": "Width",
+            "description": "Width in pixels; null for an output with no frame (audio)."
           },
           "height": {
             "anyOf": [
@@ -30452,7 +33579,8 @@
                 "type": "null"
               }
             ],
-            "title": "Height"
+            "title": "Height",
+            "description": "Height in pixels; null for an output with no frame (audio)."
           },
           "duration_ms": {
             "anyOf": [
@@ -30463,7 +33591,8 @@
                 "type": "null"
               }
             ],
-            "title": "Duration Ms"
+            "title": "Duration Ms",
+            "description": "Duration in milliseconds; null for a still image."
           },
           "fps": {
             "anyOf": [
@@ -30474,7 +33603,8 @@
                 "type": "null"
               }
             ],
-            "title": "Fps"
+            "title": "Fps",
+            "description": "The video's measured frame rate; null for a non-video output and for a video that has not been probed yet."
           },
           "error": {
             "anyOf": [
@@ -30484,7 +33614,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Why this item failed \u2014 present on a failed item within an otherwise-completed batch."
           }
         },
         "type": "object",
@@ -30505,11 +33636,13 @@
         "properties": {
           "job_id": {
             "type": "string",
-            "title": "Job Id"
+            "title": "Job Id",
+            "description": "The job this envelope describes."
           },
           "model": {
             "type": "string",
-            "title": "Model"
+            "title": "Model",
+            "description": "The resolved model id this job ran on."
           },
           "quality": {
             "anyOf": [
@@ -30543,7 +33676,8 @@
               "$ref": "#/components/schemas/OutputItem"
             },
             "type": "array",
-            "title": "Outputs"
+            "title": "Outputs",
+            "description": "The job's outputs \u2014 always an array, even for a single output; empty until the job completes."
           },
           "metrics": {
             "anyOf": [
@@ -30564,7 +33698,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Why the job failed; null unless `status` is `FAILED`."
           },
           "logs": {
             "anyOf": [
@@ -30618,7 +33753,8 @@
         "properties": {
           "job_id": {
             "type": "string",
-            "title": "Job Id"
+            "title": "Job Id",
+            "description": "The job this status describes."
           },
           "status": {
             "$ref": "#/components/schemas/JobStatus"
@@ -30647,7 +33783,8 @@
                 "type": "null"
               }
             ],
-            "title": "Estimated Completion At"
+            "title": "Estimated Completion At",
+            "description": "ISO-8601 instant this job is estimated to finish; null when no estimate exists for the model yet. Refreshed on every poll."
           },
           "logs": {
             "anyOf": [
@@ -30696,7 +33833,8 @@
                 "type": "null"
               }
             ],
-            "title": "Ttl Seconds"
+            "title": "Ttl Seconds",
+            "description": "Seconds until the token expires; omitted means the service default."
           },
           "scopes": {
             "anyOf": [
@@ -30710,7 +33848,8 @@
                 "type": "null"
               }
             ],
-            "title": "Scopes"
+            "title": "Scopes",
+            "description": "Scopes granted to the token. Omitted means every scope of the minting key; an explicit subset narrows the grant, and requesting beyond the key's scopes is a 403."
           }
         },
         "type": "object",
@@ -30720,7 +33859,8 @@
         "properties": {
           "token": {
             "type": "string",
-            "title": "Token"
+            "title": "Token",
+            "description": "The ephemeral token \u2014 a valid Bearer credential until it expires. Shown exactly once."
           },
           "expires_at": {
             "anyOf": [
@@ -30732,7 +33872,8 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "description": "ISO-8601 instant the token stops authenticating."
           }
         },
         "type": "object",
@@ -30745,11 +33886,13 @@
         "properties": {
           "key": {
             "type": "string",
-            "title": "Key"
+            "title": "Key",
+            "description": "What this bucket rolls up: `\"total\"`, an ISO date (`YYYY-MM-DD`, UTC), or a public model id \u2014 per `group_by`."
           },
           "jobs": {
             "type": "integer",
-            "title": "Jobs"
+            "title": "Jobs",
+            "description": "Jobs submitted in this bucket."
           },
           "spent": {
             "type": "number",
@@ -30780,19 +33923,22 @@
           "start": {
             "type": "string",
             "format": "date-time",
-            "title": "Start"
+            "title": "Start",
+            "description": "Window start (inclusive)."
           },
           "end": {
             "type": "string",
             "format": "date-time",
-            "title": "End"
+            "title": "End",
+            "description": "Window end (exclusive)."
           },
           "group_by": {
             "$ref": "#/components/schemas/UsageGroupBy"
           },
           "total_jobs": {
             "type": "integer",
-            "title": "Total Jobs"
+            "title": "Total Jobs",
+            "description": "Jobs submitted across the whole window."
           },
           "total_spent": {
             "type": "number",
@@ -30809,7 +33955,8 @@
               "$ref": "#/components/schemas/UsageBucket"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "One bucket per `group_by` group."
           }
         },
         "type": "object",
@@ -30830,7 +33977,8 @@
               "$ref": "#/components/schemas/VoiceSummary"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "This page of items."
           },
           "next_cursor": {
             "anyOf": [
@@ -30868,7 +34016,8 @@
                 "type": "null"
               }
             ],
-            "title": "Name"
+            "title": "Name",
+            "description": "Human-readable name."
           },
           "preview_url": {
             "anyOf": [
@@ -30879,14 +34028,16 @@
                 "type": "null"
               }
             ],
-            "title": "Preview Url"
+            "title": "Preview Url",
+            "description": "URL of a short audio sample of this voice."
           },
           "labels": {
             "additionalProperties": {
               "type": "string"
             },
             "type": "object",
-            "title": "Labels"
+            "title": "Labels",
+            "description": "Curation metadata (language, gender, accent, ...)."
           }
         },
         "type": "object",
@@ -30907,11 +34058,13 @@
                 "type": "null"
               }
             ],
-            "title": "Url"
+            "title": "Url",
+            "description": "The stored default endpoint; null when none is configured."
           },
           "enabled": {
             "type": "boolean",
             "title": "Enabled",
+            "description": "Whether the default endpoint is active.",
             "default": false
           },
           "updated_at": {
@@ -30924,7 +34077,8 @@
                 "type": "null"
               }
             ],
-            "title": "Updated At"
+            "title": "Updated At",
+            "description": "ISO-8601 instant the config last changed."
           },
           "updated_by_key_id": {
             "anyOf": [
@@ -30935,7 +34089,8 @@
                 "type": "null"
               }
             ],
-            "title": "Updated By Key Id"
+            "title": "Updated By Key Id",
+            "description": "The API key that last changed the config."
           }
         },
         "type": "object",
@@ -30947,11 +34102,13 @@
             "type": "string",
             "maxLength": 8192,
             "minLength": 1,
-            "title": "Url"
+            "title": "Url",
+            "description": "HTTPS endpoint to receive terminal webhooks for every job that names no per-job `webhook` on submit."
           },
           "enabled": {
             "type": "boolean",
             "title": "Enabled",
+            "description": "Whether the default endpoint receives deliveries; false pauses it without discarding the URL.",
             "default": true
           }
         },
@@ -30968,7 +34125,8 @@
               "$ref": "#/components/schemas/WebhookDeliverySummary"
             },
             "type": "array",
-            "title": "Data"
+            "title": "Data",
+            "description": "This page of items."
           },
           "next_cursor": {
             "anyOf": [
@@ -31014,15 +34172,18 @@
         "properties": {
           "job_id": {
             "type": "string",
-            "title": "Job Id"
+            "title": "Job Id",
+            "description": "The job whose terminal event this delivers."
           },
           "job_accessible": {
             "type": "boolean",
-            "title": "Job Accessible"
+            "title": "Job Accessible",
+            "description": "Whether GET /v3/jobs/{job_id} works for the caller \u2014 false when the job belongs to a different owner than the authenticating key."
           },
           "model": {
             "type": "string",
-            "title": "Model"
+            "title": "Model",
+            "description": "The resolved model id the job ran on."
           },
           "event_type": {
             "anyOf": [
@@ -31032,7 +34193,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The terminal event this delivery announces; null until the delivery fires \u2014 a row registered at submit has no outcome to announce while its job is still running."
           },
           "status": {
             "$ref": "#/components/schemas/WebhookDeliveryStatus"
@@ -31042,11 +34204,13 @@
           },
           "attempts": {
             "type": "integer",
-            "title": "Attempts"
+            "title": "Attempts",
+            "description": "Delivery attempts so far, cumulative across replays."
           },
           "redelivery_count": {
             "type": "integer",
             "title": "Redelivery Count",
+            "description": "How many operator replays this delivery has had; 0 means every attempt was automatic.",
             "default": 0
           },
           "redeliveries": {
@@ -31055,6 +34219,7 @@
             },
             "type": "array",
             "title": "Redeliveries",
+            "description": "One entry per operator replay, oldest first \u2014 each holds the delivery's fields as they stood when the replay was requested. Replays recorded before this history existed appear only in `redelivery_count`, so the list can be shorter.",
             "default": []
           },
           "last_response_status": {
@@ -31066,7 +34231,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Response Status"
+            "title": "Last Response Status",
+            "description": "HTTP status of the most recent attempt; null when it never got a response."
           },
           "last_error": {
             "anyOf": [
@@ -31081,12 +34247,14 @@
           },
           "webhook_url": {
             "type": "string",
-            "title": "Webhook Url"
+            "title": "Webhook Url",
+            "description": "The destination endpoint."
           },
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "description": "ISO-8601 instant the delivery was registered."
           },
           "last_attempt_at": {
             "anyOf": [
@@ -31098,7 +34266,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Attempt At"
+            "title": "Last Attempt At",
+            "description": "ISO-8601 instant of the most recent attempt; null before the first one."
           }
         },
         "type": "object",
@@ -31128,11 +34297,13 @@
           "algorithm": {
             "type": "string",
             "title": "Algorithm",
+            "description": "Signature algorithm; always `ed25519`.",
             "default": "ed25519"
           },
           "public_key": {
             "type": "string",
-            "title": "Public Key"
+            "title": "Public Key",
+            "description": "Base64-encoded ed25519 public key. Verify each delivery's signature header with it before trusting the payload."
           }
         },
         "type": "object",
@@ -31147,14 +34318,16 @@
           "requested_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Requested At"
+            "title": "Requested At",
+            "description": "ISO-8601 instant the redelivery was requested."
           },
           "status": {
             "$ref": "#/components/schemas/WebhookDeliveryStatus"
           },
           "attempts": {
             "type": "integer",
-            "title": "Attempts"
+            "title": "Attempts",
+            "description": "Cumulative attempt count as it stood when this replay was requested."
           },
           "last_response_status": {
             "anyOf": [
@@ -31165,7 +34338,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Response Status"
+            "title": "Last Response Status",
+            "description": "HTTP status of the superseded cycle's last attempt; null when it never got a response."
           },
           "last_error": {
             "anyOf": [
@@ -31188,7 +34362,8 @@
                 "type": "null"
               }
             ],
-            "title": "Last Attempt At"
+            "title": "Last Attempt At",
+            "description": "ISO-8601 instant of the superseded cycle's last attempt."
           }
         },
         "type": "object",
@@ -31204,7 +34379,8 @@
         "properties": {
           "ok": {
             "type": "boolean",
-            "title": "Ok"
+            "title": "Ok",
+            "description": "Whether the test delivery got a 2xx from the endpoint."
           },
           "response_status": {
             "anyOf": [
@@ -31215,7 +34391,8 @@
                 "type": "null"
               }
             ],
-            "title": "Response Status"
+            "title": "Response Status",
+            "description": "HTTP status the endpoint returned; null when the request never got a response."
           },
           "error": {
             "anyOf": [
@@ -31226,7 +34403,8 @@
                 "type": "null"
               }
             ],
-            "title": "Error"
+            "title": "Error",
+            "description": "Why the test failed; null on success."
           }
         },
         "type": "object",
@@ -31243,6 +34421,7 @@
             "type": "string"
           },
           "model": {
+            "description": "The resolved model id this job runs on.",
             "title": "Model",
             "type": "string"
           },
@@ -31295,6 +34474,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -31381,12 +34561,14 @@
           },
           "stability": {
             "default": 1.0,
+            "description": "Voice stability, from 0 to 1. Higher values give a steadier, more consistent delivery; lower values allow more expressive variation between generations.",
             "maximum": 1.0,
             "minimum": 0.0,
             "type": "number"
           },
           "speed": {
             "default": 1.0,
+            "description": "Speech rate multiplier; 1.0 is the voice's natural pace.",
             "maximum": 1.2,
             "minimum": 0.7,
             "type": "number"
@@ -31446,12 +34628,14 @@
           },
           "stability": {
             "default": 1.0,
+            "description": "Voice stability, from 0 to 1. Higher values give a steadier, more consistent delivery; lower values allow more expressive variation between generations.",
             "maximum": 1.0,
             "minimum": 0.0,
             "type": "number"
           },
           "speed": {
             "default": 1.0,
+            "description": "Speech rate multiplier; 1.0 is the voice's natural pace.",
             "maximum": 1.2,
             "minimum": 0.7,
             "type": "number"
@@ -31511,12 +34695,14 @@
           },
           "stability": {
             "default": 1.0,
+            "description": "Voice stability, from 0 to 1. Higher values give a steadier, more consistent delivery; lower values allow more expressive variation between generations.",
             "maximum": 1.0,
             "minimum": 0.0,
             "type": "number"
           },
           "speed": {
             "default": 1.0,
+            "description": "Speech rate multiplier; 1.0 is the voice's natural pace.",
             "maximum": 1.2,
             "minimum": 0.7,
             "type": "number"
@@ -31576,12 +34762,14 @@
           },
           "stability": {
             "default": 1.0,
+            "description": "Voice stability, from 0 to 1. Higher values give a steadier, more consistent delivery; lower values allow more expressive variation between generations.",
             "maximum": 1.0,
             "minimum": 0.0,
             "type": "number"
           },
           "speed": {
             "default": 1.0,
+            "description": "Speech rate multiplier; 1.0 is the voice's natural pace.",
             "maximum": 1.2,
             "minimum": 0.7,
             "type": "number"
@@ -31640,6 +34828,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -31737,6 +34926,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -31827,6 +35017,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -31936,6 +35127,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -32105,6 +35297,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -32274,6 +35467,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -32442,6 +35636,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -32615,6 +35810,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -32771,6 +35967,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -32922,6 +36119,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -33237,6 +36435,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -33396,6 +36595,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -33572,6 +36772,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -33719,6 +36920,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -33903,6 +37105,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -34152,6 +37355,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -34344,6 +37548,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -34542,6 +37747,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -34733,6 +37939,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -34821,6 +38028,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -34920,6 +38128,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -34995,6 +38204,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -35066,6 +38276,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -35232,6 +38443,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -35394,6 +38606,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -35556,6 +38769,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -35726,6 +38940,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -35912,6 +39127,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -36180,6 +39396,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -36583,6 +39800,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -36940,6 +40158,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -37243,6 +40462,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -37333,6 +40553,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -37492,6 +40713,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -37818,6 +41040,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -38052,12 +41275,14 @@
           },
           "stability": {
             "default": 1.0,
+            "description": "Voice stability, from 0 to 1. Higher values give a steadier, more consistent delivery; lower values allow more expressive variation between generations.",
             "maximum": 1.0,
             "minimum": 0.0,
             "type": "number"
           },
           "speed": {
             "default": 1.0,
+            "description": "Speech rate multiplier; 1.0 is the voice's natural pace.",
             "maximum": 1.2,
             "minimum": 0.7,
             "type": "number"
@@ -38117,12 +41342,14 @@
           },
           "stability": {
             "default": 1.0,
+            "description": "Voice stability, from 0 to 1. Higher values give a steadier, more consistent delivery; lower values allow more expressive variation between generations.",
             "maximum": 1.0,
             "minimum": 0.0,
             "type": "number"
           },
           "speed": {
             "default": 1.0,
+            "description": "Speech rate multiplier; 1.0 is the voice's natural pace.",
             "maximum": 1.2,
             "minimum": 0.7,
             "type": "number"
@@ -38181,6 +41408,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -38319,6 +41547,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -38464,6 +41693,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -38604,6 +41834,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -38777,6 +42008,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -38973,6 +42205,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -39160,6 +42393,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -39247,6 +42481,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -39337,6 +42572,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -39487,6 +42723,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -39635,6 +42872,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -39743,6 +42981,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -39951,6 +43190,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -40384,6 +43624,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -40768,6 +44009,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -40930,6 +44172,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -41091,6 +44334,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -41252,6 +44496,7 @@
           },
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -41408,6 +44653,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -41563,6 +44809,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -41744,6 +44991,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -41897,6 +45145,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -42074,6 +45323,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -42398,6 +45648,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -42427,7 +45678,6 @@
           "resolution": {
             "description": "Output resolution.",
             "enum": [
-              "360p",
               "540p",
               "720p",
               "1080p"
@@ -42602,14 +45852,7 @@
               "start_image"
             ],
             "properties": {
-              "aspect_ratio": false,
-              "resolution": {
-                "enum": [
-                  "540p",
-                  "720p",
-                  "1080p"
-                ]
-              }
+              "aspect_ratio": false
             }
           },
           {
@@ -42660,6 +45903,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -42689,7 +45933,6 @@
           "resolution": {
             "description": "Output resolution.",
             "enum": [
-              "360p",
               "540p",
               "720p",
               "1080p"
@@ -42821,6 +46064,7 @@
         "properties": {
           "num_outputs": {
             "default": 1,
+            "description": "Number of outputs generated per job. Only 1 is supported.",
             "type": "integer",
             "enum": [
               1
@@ -43142,11 +46386,13 @@
         "properties": {
           "job_id": {
             "type": "string",
-            "title": "Job Id"
+            "title": "Job Id",
+            "description": "The job this envelope describes."
           },
           "model": {
             "type": "string",
-            "title": "Model"
+            "title": "Model",
+            "description": "The resolved model id this job ran on."
           },
           "quality": {
             "anyOf": [
@@ -43180,7 +46426,8 @@
               "$ref": "#/components/schemas/OutputItem"
             },
             "type": "array",
-            "title": "Outputs"
+            "title": "Outputs",
+            "description": "The job's outputs \u2014 always an array, even for a single output; empty until the job completes."
           },
           "metrics": {
             "anyOf": [
@@ -43201,7 +46448,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Why the job failed; null unless `status` is `FAILED`."
           }
         },
         "type": "object",


### PR DESCRIPTION
Refreshes both published schemas and reapplies the
documentation-only annotations layered on top of them.

- `openapi-v3.json` from `https://api.hedra.com/v3/openapi.json`,
  with `openapi-v3-overrides.json` applied.
- `openapi.json` (v2, legacy) from
  `https://api.hedra.com/public/openapi.json`, with
  `openapi-overrides.json` applied.

The v3 schema carries a `POST /models/{slug}` operation per model,
so model launches and retirements show up here as added or removed
endpoints.