### PR TITLE
docs: add v3 quickstart and reorder API reference groups

### DIFF
--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -24,6 +24,9 @@ jobs:
             --output openapi-v3.json \
             --overrides openapi-v3-overrides.json
 
+      - name: Regenerate the v3 API Reference navigation
+        run: python3 scripts/generate_v3_reference_nav.py
+
       - name: Sync the v2 (legacy) schema
         run: |
           python3 scripts/sync_openapi.py \

--- a/docs.json
+++ b/docs.json
@@ -110,6 +110,12 @@
         "icon": "code",
         "groups": [
           {
+            "group": "Getting Started",
+            "pages": [
+              "pages/developer/v3/quickstart"
+            ]
+          },
+          {
             "group": "Guides",
             "pages": [
               "pages/developer/v3/chain-generations",

--- a/docs.json
+++ b/docs.json
@@ -133,7 +133,146 @@
             "openapi": {
               "source": "/openapi-v3.json",
               "directory": "api-reference/v3"
-            }
+            },
+            "pages": [
+              {
+                "group": "Run a model",
+                "pages": [
+                  "POST /models/dreamina-31",
+                  "POST /models/elevenlabs-flash-multilingual-v2",
+                  "POST /models/elevenlabs-flash-v2",
+                  "POST /models/elevenlabs-multilingual-v2",
+                  "POST /models/elevenlabs-v3",
+                  "POST /models/flux-11-pro",
+                  "POST /models/flux-11-ultra",
+                  "POST /models/flux-dev",
+                  "POST /models/flux-kontext-max",
+                  "POST /models/flux-kontext-pro",
+                  "POST /models/flux2-flex",
+                  "POST /models/flux2-klein-9b",
+                  "POST /models/flux2-max",
+                  "POST /models/flux2-pro",
+                  "POST /models/gemini-omni-flash",
+                  "POST /models/gpt-image-15",
+                  "POST /models/gpt-image-2",
+                  "POST /models/grok-imagine",
+                  "POST /models/grok-video",
+                  "POST /models/happy-horse",
+                  "POST /models/hedra-avatar",
+                  "POST /models/hedra-character-3",
+                  "POST /models/hidream-o1-image",
+                  "POST /models/ideogram-v2",
+                  "POST /models/ideogram-v4",
+                  "POST /models/imagen3",
+                  "POST /models/imagen4",
+                  "POST /models/kling-16",
+                  "POST /models/kling-21-master",
+                  "POST /models/kling-25-turbo",
+                  "POST /models/kling-26-pro",
+                  "POST /models/kling-ai-avatar-v2",
+                  "POST /models/kling-o1",
+                  "POST /models/kling-o3",
+                  "POST /models/kling-v3",
+                  "POST /models/ltx-2-3",
+                  "POST /models/luma-ray-32",
+                  "POST /models/mai-image-2-5",
+                  "POST /models/minimax-hailuo-02",
+                  "POST /models/minimax-hailuo-23",
+                  "POST /models/minimax-speech-25-hd-preview",
+                  "POST /models/minimax-speech-25-turbo-preview",
+                  "POST /models/nano-banana",
+                  "POST /models/nano-banana-2",
+                  "POST /models/nano-banana-pro",
+                  "POST /models/omnihuman-15",
+                  "POST /models/pixverse-v6",
+                  "POST /models/qwen-image-2",
+                  "POST /models/recraft-v3",
+                  "POST /models/reve-21",
+                  "POST /models/reve-21-edit",
+                  "POST /models/reve-21-remix",
+                  "POST /models/sana",
+                  "POST /models/seedance-15-pro",
+                  "POST /models/seedance-20",
+                  "POST /models/seedance-20-mini",
+                  "POST /models/seedream-40",
+                  "POST /models/seedream-45",
+                  "POST /models/seedream-50-lite",
+                  "POST /models/seedream-50-pro",
+                  "POST /models/sora-2-pro",
+                  "POST /models/veed-fabric-10",
+                  "POST /models/veo-2",
+                  "POST /models/veo-3",
+                  "POST /models/veo-31",
+                  "POST /models/vidu-q3",
+                  "POST /models/vidu-q3-reference",
+                  "POST /models/wan-2-7"
+                ]
+              },
+              {
+                "group": "Models",
+                "pages": [
+                  "GET /models",
+                  "GET /models/{model}",
+                  "GET /models/{model}/jobs",
+                  "GET /models/{model}/voices",
+                  "GET /models/{model}/openapi.json",
+                  "POST /models/{model}/estimate"
+                ]
+              },
+              {
+                "group": "Jobs",
+                "pages": [
+                  "GET /jobs",
+                  "GET /jobs/{job_id}",
+                  "GET /jobs/{job_id}/status",
+                  "GET /jobs/{job_id}/logs",
+                  "GET /jobs/{job_id}/stream"
+                ]
+              },
+              {
+                "group": "Webhooks",
+                "pages": [
+                  "GET /webhooks/public-key",
+                  "GET /webhooks/default",
+                  "PUT /webhooks/default",
+                  "DELETE /webhooks/default",
+                  "POST /webhooks/default/test",
+                  "GET /webhooks/deliveries",
+                  "POST /webhooks/deliveries/{job_id}/redeliver",
+                  "WEBHOOK job.completed",
+                  "WEBHOOK job.failed"
+                ]
+              },
+              {
+                "group": "Log drains",
+                "pages": [
+                  "GET /log-drains",
+                  "POST /log-drains",
+                  "GET /log-drains/{drain_id}",
+                  "PATCH /log-drains/{drain_id}",
+                  "DELETE /log-drains/{drain_id}",
+                  "POST /log-drains/{drain_id}/test"
+                ]
+              },
+              {
+                "group": "Access",
+                "pages": [
+                  "POST /keys",
+                  "GET /keys",
+                  "POST /keys/{key_id}/rotate",
+                  "DELETE /keys/{key_id}",
+                  "POST /tokens",
+                  "POST /files"
+                ]
+              },
+              {
+                "group": "Billing",
+                "pages": [
+                  "GET /balance",
+                  "GET /usage"
+                ]
+              }
+            ]
           }
         ]
       },

--- a/openapi-v3-overrides.json
+++ b/openapi-v3-overrides.json
@@ -1,1 +1,11 @@
-{}
+{
+  "x-tag-order": [
+    "Run a model",
+    "Models",
+    "Jobs",
+    "Webhooks",
+    "Log drains",
+    "Access",
+    "Billing"
+  ]
+}

--- a/openapi-v3.json
+++ b/openapi-v3.json
@@ -46478,24 +46478,16 @@
   },
   "tags": [
     {
-      "name": "Models",
-      "description": "Discover models and estimate cost."
-    },
-    {
       "name": "Run a model",
       "description": "One typed submit endpoint per model \u2014 titled `Run <name> (<id>)`, so the model you know by name is the operation you call. Every one returns the same `202` job envelope; track it under Jobs."
     },
     {
+      "name": "Models",
+      "description": "Discover models and estimate cost."
+    },
+    {
       "name": "Jobs",
       "description": "Poll, stream, and list submitted jobs."
-    },
-    {
-      "name": "Access",
-      "description": "API keys, browser tokens, and file uploads."
-    },
-    {
-      "name": "Billing",
-      "description": "Balance and usage, in US dollars."
     },
     {
       "name": "Webhooks",
@@ -46504,6 +46496,14 @@
     {
       "name": "Log drains",
       "description": "Stream signed job lifecycle logs to HTTPS destinations.\n\n**Why the last batch failed.** `last_error` is the same error envelope a failed job returns from `GET /jobs/{job_id}`, not a free-text diagnostic. It is null until a batch fails and is cleared again on the next success. Its `code` comes from the one error vocabulary this API uses, narrowed for drain delivery to this set:\n\n| `code` | Means |\n| --- | --- |\n| `DEADLINE_EXCEEDED` | Your destination did not respond before the delivery timeout. |\n| `UNAVAILABLE` | Your destination could not be reached (DNS, TLS, or connection failure) or answered `5xx` \u2014 or redirected, which is never followed. |\n| `RESOURCE_EXHAUSTED` | Your destination answered `429`. |\n| `UNAUTHORIZED` | Your destination answered `401`. |\n| `PERMISSION_DENIED` | Your destination answered `403`. |\n| `NOT_FOUND` | Your destination answered `404`. |\n| `INVALID_ARGUMENT` | Your destination answered some other `4xx`. |\n| `FAILED_PRECONDITION` | The URL is not a permitted log drain target \u2014 it resolves to a blocked address range. Fix the URL; retrying will not help. |\n| `INTERNAL` | Hedra could not prepare the batch. |\n| `UNKNOWN` | No classification is available, including for drains that last failed before this field became structured. |\n\n`retryable` describes the condition, not what Hedra did: every failed batch is requeued until the drain auto-disables, so it answers whether fixing the destination and re-enabling is likely to help. The `message` is a fixed summary \u2014 your destination's URL, headers, credentials, and response body are never echoed back, so treat your own logs, not this field, as the record of what your destination returned.\n\n`disabled_reason` answers a different question and stays its own small vocabulary: `consecutive_failures` when five batches in a row failed, `disabled_by_user` when you turned the drain off."
+    },
+    {
+      "name": "Access",
+      "description": "API keys, browser tokens, and file uploads."
+    },
+    {
+      "name": "Billing",
+      "description": "Balance and usage, in US dollars."
     }
   ],
   "webhooks": {

--- a/pages/developer/v3/quickstart.mdx
+++ b/pages/developer/v3/quickstart.mdx
@@ -1,0 +1,94 @@
+---
+title: "Developer Platform Quickstart"
+sidebarTitle: "Quickstart"
+description: "Create an API key, fund the API wallet, and run your first generation on the Hedra v3 API in minutes."
+---
+
+Every leading image, video, and audio model behind one endpoint, one key, and
+one bill. Browse the [model catalog](https://www.hedra.com/develop/models),
+pick a model, and ship — the same key and the same job lifecycle work for all
+of them.
+
+### Step 1: Create an API key
+
+Generate a key in the [developer console](https://www.hedra.com/develop/api-keys).
+Every request authenticates with it:
+
+```
+Authorization: Key <key_id>:<secret>
+```
+
+### Step 2: Fund the API wallet
+
+The API bills a **prepaid wallet** held in US dollars. It is separate from your
+Hedra Studio balance, and a workspace starts with **$0.00** in it — nothing you
+buy or hold in Studio moves money into it. Until it is funded, every generation
+is refused with `402 INSUFFICIENT_BALANCE`.
+
+Add funds in the [developer console](https://www.hedra.com/develop/billing),
+and read the wallet any time with `GET /balance`.
+
+<Note>
+  Uploading inputs with `POST /files` is free and works on an empty wallet, so
+  you can stage a request end-to-end and only meet the billing gate at submit.
+</Note>
+
+### Step 3: Pick a model
+
+`GET /models` lists every model with its `id` and human `name`, so a model you
+know by name ("GPT Image 2") maps straight to the id you submit to
+(`gpt-image-2`). Each model publishes its typed input schema at
+`GET /models/{id}/openapi.json`.
+
+```bash
+curl https://api.hedra.com/v3/models -H "Authorization: Key $HEDRA_KEY"
+```
+
+To know the price before you run, ask for an estimate:
+
+```bash
+curl -X POST https://api.hedra.com/v3/models/gpt-image-2/estimate \
+  -H "Authorization: Key $HEDRA_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"prompt": "a space cat", "quality": "medium", "aspect_ratio": "1:1", "resolution": "1K"}}'
+```
+
+### Step 4: Submit, poll, download
+
+Every generation follows the same lifecycle: submit a job, poll it, then read
+the output URL.
+
+```bash
+# 1. Submit — capture the job id from the 202 ack
+JOB_ID=$(curl -sS -X POST https://api.hedra.com/v3/models/gpt-image-2 \
+  -H "Authorization: Key $HEDRA_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"prompt": "a space cat", "quality": "medium", "aspect_ratio": "1:1", "resolution": "1K"}}' | jq -r .job_id)
+
+# 2. Poll until status is COMPLETED (or FAILED)
+curl https://api.hedra.com/v3/jobs/$JOB_ID/status -H "Authorization: Key $HEDRA_KEY"
+
+# 3. Read the result — outputs[].url holds the generated file
+curl https://api.hedra.com/v3/jobs/$JOB_ID -H "Authorization: Key $HEDRA_KEY"
+```
+
+Generated media is retained for **48 hours** after a job completes — download
+outputs to your own storage, or chain them into the next job by `asset_id`.
+
+### Next steps
+
+<CardGroup cols={2}>
+  <Card title="Model catalog" href="/pages/developer/v3/model-catalog">
+    Every model behind the endpoint, with ids, names, and what each one is for.
+  </Card>
+  <Card title="Chain generations" href="/pages/developer/v3/chain-generations">
+    Reuse a completed job's output as an asset in the next submit.
+  </Card>
+  <Card title="Quality levels" href="/pages/developer/v3/quality-levels">
+    How the quality tiers map to cost and latency across models.
+  </Card>
+</CardGroup>
+
+### Enterprise
+
+For volume pricing and custom limits, [talk to us](https://www.hedra.com/enterprise).

--- a/scripts/generate_v3_reference_nav.py
+++ b/scripts/generate_v3_reference_nav.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Regenerate the v3 API Reference navigation in docs.json from openapi-v3.json.
+
+Mintlify's OpenAPI auto-population sorts tag groups alphabetically, so the
+reference navigation is written out explicitly instead. Groups follow the order
+of the spec's top-level ``tags`` array (which ``sync_openapi.py`` orders via
+the ``x-tag-order`` override); operations keep the spec's path order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+HTTP_METHODS = ("get", "post", "put", "patch", "delete")
+OPENAPI_SOURCE = "/openapi-v3.json"
+OPENAPI_DIRECTORY = "api-reference/v3"
+PRODUCT_NAME = "Developer platform"
+GROUP_NAME = "API Reference"
+WEBHOOK_TAG = "Webhooks"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", type=Path, default=REPOSITORY_ROOT / "openapi-v3.json")
+    parser.add_argument("--docs", type=Path, default=REPOSITORY_ROOT / "docs.json")
+    return parser.parse_args()
+
+
+def build_reference_group(spec: dict[str, Any]) -> dict[str, Any]:
+    pages_by_tag: dict[str, list[str]] = {}
+    for path, methods in spec["paths"].items():
+        for method, operation in methods.items():
+            if method not in HTTP_METHODS:
+                continue
+            tags = operation.get("tags")
+            if not tags:
+                raise ValueError(f"Untagged operation: {method.upper()} {path}")
+            pages_by_tag.setdefault(tags[0], []).append(f"{method.upper()} {path}")
+
+    for name in spec.get("webhooks", {}):
+        pages_by_tag.setdefault(WEBHOOK_TAG, []).append(f"WEBHOOK {name}")
+
+    ordered_names = [tag["name"] for tag in spec.get("tags", [])]
+    ordered_names += sorted(set(pages_by_tag) - set(ordered_names))
+
+    return {
+        "group": GROUP_NAME,
+        "openapi": {"source": OPENAPI_SOURCE, "directory": OPENAPI_DIRECTORY},
+        "pages": [
+            {"group": name, "pages": pages_by_tag[name]}
+            for name in ordered_names
+            if name in pages_by_tag
+        ],
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    spec = json.loads(args.spec.read_text())
+    docs = json.loads(args.docs.read_text())
+
+    for product in docs["navigation"]["products"]:
+        if product.get("product") != PRODUCT_NAME:
+            continue
+        for index, group in enumerate(product["groups"]):
+            if group.get("group") == GROUP_NAME:
+                product["groups"][index] = build_reference_group(spec)
+                break
+        else:
+            raise ValueError(f"No {GROUP_NAME!r} group in {PRODUCT_NAME!r}")
+        break
+    else:
+        raise ValueError(f"No {PRODUCT_NAME!r} product in docs.json")
+
+    args.docs.write_text(json.dumps(docs, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_openapi.py
+++ b/scripts/sync_openapi.py
@@ -55,6 +55,19 @@ def merge(target: dict[str, Any], override: dict[str, Any]) -> None:
             target[key] = value
 
 
+def apply_tag_order(document: dict[str, Any], order: list[str]) -> None:
+    """Reorder the top-level tags array without pinning upstream tag content.
+
+    Tags named in ``order`` come first, in that order; tags the source adds
+    later keep their relative order after them.
+    """
+    tags = document.get("tags")
+    if not isinstance(tags, list):
+        return
+    rank = {name: index for index, name in enumerate(order)}
+    tags.sort(key=lambda tag: rank.get(tag.get("name"), len(order)))
+
+
 def main() -> None:
     args = parse_args()
     document = load_source(args.source)
@@ -64,7 +77,14 @@ def main() -> None:
     if not isinstance(overrides, dict):
         raise ValueError("OpenAPI overrides must contain a JSON object")
 
+    tag_order = overrides.pop("x-tag-order", None)
     merge(document, overrides)
+    if tag_order is not None:
+        if not isinstance(tag_order, list) or not all(
+            isinstance(name, str) for name in tag_order
+        ):
+            raise ValueError("x-tag-order must be a list of tag names")
+        apply_tag_order(document, tag_order)
     args.output.write_text(json.dumps(document, indent=2) + "\n")
 
 


### PR DESCRIPTION
## Summary

Two changes to the Developer Platform docs:

**New quickstart page** (`pages/developer/v3/quickstart.mdx`), surfaced as a new *Getting Started* group at the top of the Developer platform nav. It walks the v3 onboarding path: create an API key (`Authorization: Key <key_id>:<secret>`), fund the prepaid API wallet (separate from Studio, `402 INSUFFICIENT_BALANCE` until funded, free `POST /files` staging), discover models (`GET /models`, per-model `openapi.json`, `POST /models/{model}/estimate`), then the submit → poll → download lifecycle. Ends with next-step cards into the existing model-catalog, chain-generations, and quality-levels pages.

**API Reference group reorder** to *Run a model, Models, Jobs, Webhooks, Log drains, Access, Billing*. Mintlify sorts auto-populated OpenAPI tag groups **alphabetically** and ignores the spec's `tags` order (verified against both production and the preview), so auto-population can't express a custom order. The nav is therefore written out explicitly in `docs.json` — every endpoint listed as `"METHOD /path"` plus the two OpenAPI 3.1 webhook events as `"WEBHOOK <name>"` — generated by the new `scripts/generate_v3_reference_nav.py`, which the nightly sync workflow now runs after syncing the spec, so model launches/retirements keep flowing into the nav without manual edits. Group order follows the spec's `tags` array, which `sync_openapi.py` orders via the new `x-tag-order` key in `openapi-v3-overrides.json` — that override stays the single knob for reordering, without pinning upstream tag descriptions. Generated page URLs are unchanged (same `api-reference/v3/...` slugs), so no redirects are needed.

`Access` wasn't part of the requested order; it's slotted second-to-last to keep Billing at the bottom — move it by editing `x-tag-order` in `openapi-v3-overrides.json` and re-running the two scripts.

## Test plan

- [x] Preview deployment renders the API Reference groups in the requested order (verified via the preview's `llms.txt`)
- [x] Webhook event pages (`job.completed`, `job.failed`) render at their pre-existing URLs via the `WEBHOOK <name>` nav entries
- [x] Quickstart appears under *Getting Started* and renders in the preview
- [x] `generate_v3_reference_nav.py` covers all 100 operations + 2 webhooks; fails loudly on untagged operations
- [x] v2 sync path regression: `sync_openapi.py` output without `x-tag-order` is byte-identical to before
- [x] `docs.json`, `openapi-v3.json`, `openapi-v3-overrides.json` all parse as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEBVrFFr3THi8Upec3FFf3
