### PR TITLE
Add an About Hedra Mintlify landing page

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -1,0 +1,27 @@
+---
+title: "Hedra Documentation"
+description: "Hedra is a visual research and inference platform for turning ideas into exceptional visual work."
+---
+
+Move from research and creative direction to production with Hedra Agent, or
+build directly with state-of-the-art visual media models through the Developer
+platform.
+
+<CardGroup cols={2}>
+  <Card
+    title="Agent platform"
+    icon="message-circle"
+    href="/pages/app/getting-started/overview"
+  >
+    Turn ideas into finished visual work with Hedra Agent, Spaces, reusable
+    skills, and manual creative tools.
+  </Card>
+  <Card
+    title="Developer platform"
+    icon="code"
+    href="/pages/developer/v3/quickstart"
+  >
+    Build with Hedra's inference engine and access the most powerful open- and
+    closed-source models through Hedra's infrastructure.
+  </Card>
+</CardGroup>

--- a/index.mdx
+++ b/index.mdx
@@ -1,11 +1,16 @@
 ---
-title: "Hedra Documentation"
-description: "Hedra is a visual research and inference platform for turning ideas into exceptional visual work."
+title: "About Hedra"
+description: "Hedra's mission is to build general visual intelligence."
 ---
 
-Move from research and creative direction to production with Hedra Agent, or
-build directly with state-of-the-art visual media models through the Developer
-platform.
+Hedra builds state-of-the-art models and the infrastructure to accelerate and
+deploy visual intelligence at scale.
+
+Hedra is used by millions for research, ideation, and the production of the
+world's best visual work.
+
+Move from research to production with Hedra Agent, or build directly with our
+state-of-the-art inference engine through the Developer platform.
 
 <CardGroup cols={2}>
   <Card


### PR DESCRIPTION
## What changed

- Adds a root `index.mdx` for an **About Hedra** landing page.
- Leads with Hedra's mission to build general visual intelligence.
- Routes visitors to the Agent platform and Developer platform through focused cards.
- Keeps the landing page out of the Mintlify sidebar, preserving the existing navigation hierarchy and styling.

## Why

Without a root index page, `/docs` resolves to the first navigable document, **Meet Hedra Agent**. That makes an Agent-specific page represent the entire documentation site and gives Google an undesirable branded sitelink candidate.

The existing `seo.indexing: "all"` setting keeps the new root page indexable even though it is not listed in the sidebar. The website already links to `/docs`.

## Impact

`/docs` now serves a distinct documentation landing page while all existing documentation routes and the sidebar remain unchanged.

## Validation

- Mintlify `broken-links`: no broken links found
- Local Mintlify preview returned the root page as HTTP 200
- Verified rendered title, description, Agent link, and Developer link
- Visually verified that the existing sidebar has no new indentation, wrapper, or active-page indicator
