### PR TITLE
Give the Agent overview a description distinct from /app/home

### DIFF
--- a/pages/app/getting-started/overview.mdx
+++ b/pages/app/getting-started/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Meet Hedra Agent"
-description: "The Hedra Agent is an agentic workspace for research, visual inference, and creative production."
+description: "Get started with the Hedra Agent: tell it your goal, give it context, and refine finished video, image, and audio in one persistent workspace."
 ---
 
 Hedra turns an idea into finished visual work. Tell the agent what you want, give it


### PR DESCRIPTION
`pages/app/getting-started/overview.mdx` carried a meta description byte-identical to the one `www.hedra.com/app/home` serves:

> The Hedra Agent is an agentic workspace for research, visual inference, and creative production.

Both URLs are indexed, so Google sees two pages claiming to be the Agent and surfaces both as sitelinks on the `hedra` brand SERP — "Agent" and "Meet Hedra Agent" side by side, wasting a slot.

New description is the getting-started guide in its own voice:

> Get started with the Hedra Agent: tell it your goal, give it context, and refine finished video, image, and audio in one persistent workspace.

`/app/home` keeps the product line. This is the docs-side half of the sitelink cleanup; the website side is hedra-labs/website#6483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)